### PR TITLE
docs: add root code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,63 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers of ApexChainx pledge to make participation
+in our project and community a harassment-free experience for everyone.
+
+We do not tolerate harassment of participants in any form.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Using welcoming and inclusive language
+- Respecting differing viewpoints and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community
+- Showing empathy toward other community members
+- Being respectful in disagreements and criticism
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal attacks
+- Public or private harassment
+- Publishing others’ private information without explicit permission
+- Any other conduct that would be considered inappropriate in a professional community
+
+## Scope
+
+This Code of Conduct applies to all project spaces including, but not limited to, this repository,
+issues, pull requests, reviews, discussions, and public forums where ApexChainx contributors
+are representing the project.
+
+## Enforcement
+
+Project leaders may remove, edit, or reject comments, commits, issues, and pull requests that are
+affirmatively incompatible with this Code of Conduct. If a participant engages in unacceptable
+behavior, project leaders may impose temporary or permanent bans from project spaces.
+
+Enforcement contact: open an issue at
+https://github.com/ApexChainx/ApexChainx-Contracts/issues and mention `Code of Conduct` in the
+title, or contact a maintainer directly through the repository maintainers list.
+
+## Reporting
+
+If you believe someone is violating this Code of Conduct, please report it promptly by:
+
+1. Opening a GitHub issue with clear evidence and context
+2. Including links, screenshots, usernames, and timestamps where possible
+3. Keeping the report respectful and fact-based
+
+We will handle reports confidentially and respond promptly.
+
+## Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing the Code of Conduct. They are
+expected to apply these standards consistently.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 
 # ApexChainx Smart Contracts
 
+We follow a contributor code of conduct. See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+and [`CONTRIBUTING.md`](CONTRIBUTING.md) before contributing.
+
 ## Frequently Asked Questions
 
 ### What is ApexChainx?


### PR DESCRIPTION
## What changed
- Add root  to satisfy the existing contribution guide reference.
- Add a README pointer to  and .
- Use Contributor Covenant v2.1 language with reporting and enforcement guidance.

Closes #6