### PR TITLE
Fix/sla config version idempotency

### DIFF
--- a/apexchainx_calculator/src/coordination_harness.rs
+++ b/apexchainx_calculator/src/coordination_harness.rs
@@ -227,7 +227,9 @@ mod coordination_harness_tests {
 
         // Simulate two successful calls by directly registering compensations
         // (the actual call path would register them via safety.call())
+        let mock_contract = Address::generate(&env);
         safety.compensation_stack.push_back((
+            mock_contract.clone(),
             symbol_short!("lock_fnds"),
             cross_contract_safety::CompensationAction {
                 tag: cross_contract_safety::COMP_UNLOCK_FUNDS,
@@ -235,6 +237,7 @@ mod coordination_harness_tests {
             },
         ));
         safety.compensation_stack.push_back((
+            mock_contract,
             symbol_short!("rel_pay"),
             cross_contract_safety::CompensationAction {
                 tag: cross_contract_safety::COMP_REVERSE_SETTLE,

--- a/apexchainx_calculator/src/cross_contract_safety.rs
+++ b/apexchainx_calculator/src/cross_contract_safety.rs
@@ -192,16 +192,12 @@ impl CrossContractSafety {
     /// This should be called after a fatal error to undo all prior
     /// successful cross-contract calls.
     pub fn rollback_all(&mut self, env: &Env) {
-        while let Some((contract_id, _function_name, action)) = self.compensation_stack.pop_back()
-        {
+        while let Some((contract_id, _function_name, action)) = self.compensation_stack.pop_back() {
             // Invoke the compensation function on the original target contract.
             // We ignore the result because there is no further recovery possible
             // during rollback.
-            let _ = env.try_invoke_contract::<Val, Val>(
-                &contract_id,
-                &action.tag,
-                action.args.clone(),
-            );
+            let _ =
+                env.try_invoke_contract::<Val, Val>(&contract_id, &action.tag, action.args.clone());
         }
     }
 

--- a/apexchainx_calculator/src/cross_contract_safety.rs
+++ b/apexchainx_calculator/src/cross_contract_safety.rs
@@ -20,16 +20,23 @@
 //!
 //! ```ignore
 //! let mut safety = CrossContractSafety::new(&env);
-//! safety.call(contract_id, "lock_funds", args, || {
-//!     // compensation: unlock the funds
-//! });
-//! safety.call(contract_id, "release_payment", args, || {
-//!     // compensation: reverse the release
-//! });
-//! let result = safety.finalize()?; // rolls back on error
+//! safety.call(&env, &contract_id, &lock_funds_fn, args, unlock_tag, unlock_args);
+//! safety.call(&env, &contract_id, &release_fn, args, release_tag, release_args);
+//! safety.finalize(&env); // happy path – clear the compensation stack
+//! ```
+//!
+//! On a fatal error, call `rollback_all()` to invoke all registered
+//! compensations in reverse order:
+//!
+//! ```ignore
+//! if let Err(result) = safety.call(&env, &contract_id, &fn_name, args, tag, comp_args) {
+//!     safety.rollback_all(&env);
+//!     return Err(result);
+//! }
+//! safety.finalize(&env);
 //! ```
 
-use soroban_sdk::{contracttype, Env, Symbol, Val, Vec};
+use soroban_sdk::{contracttype, Address, Env, Symbol, Val, Vec};
 
 /// Status of a cross-contract call.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -116,7 +123,8 @@ pub fn requires_rollback(status: CrossContractCallStatus) -> bool {
 /// are compensated in reverse order.
 pub struct CrossContractSafety {
     /// Stack of compensation actions registered for each successful call.
-    pub(crate) compensation_stack: Vec<(Symbol, CompensationAction)>,
+    /// Each entry stores (contract_id, function_name, compensation_action).
+    pub(crate) compensation_stack: Vec<(Address, Symbol, CompensationAction)>,
 }
 
 impl CrossContractSafety {
@@ -132,7 +140,8 @@ impl CrossContractSafety {
     ///
     /// Returns `Ok(SafeCallResult)` on success or recoverable errors, and
     /// `Err(result)` on fatal errors.  When `Err` is returned the caller
-    /// should call `rollback_all()` to unwind prior calls.
+    /// should call [`rollback_all`](Self::rollback_all) to unwind prior
+    /// calls.
     pub fn call(
         &mut self,
         env: &Env,
@@ -148,6 +157,7 @@ impl CrossContractSafety {
             CrossContractCallStatus::Success | CrossContractCallStatus::RecoverableError => {
                 // Register compensation so we can undo this call later if needed
                 self.compensation_stack.push_back((
+                    contract_id.clone(),
                     function_name.clone(),
                     CompensationAction {
                         tag: compensation_tag,
@@ -175,6 +185,33 @@ impl CrossContractSafety {
     pub fn has_pending(&self) -> bool {
         !self.compensation_stack.is_empty()
     }
+
+    /// Walk the compensation stack in reverse order and invoke each
+    /// registered compensation action on its target contract.
+    ///
+    /// This should be called after a fatal error to undo all prior
+    /// successful cross-contract calls.
+    pub fn rollback_all(&mut self, env: &Env) {
+        while let Some((contract_id, _function_name, action)) = self.compensation_stack.pop_back()
+        {
+            // Invoke the compensation function on the original target contract.
+            // We ignore the result because there is no further recovery possible
+            // during rollback.
+            let _ = env.try_invoke_contract::<Val, Val>(
+                &contract_id,
+                &action.tag,
+                action.args.clone(),
+            );
+        }
+    }
+
+    /// Confirm the happy path and clear all registered compensations.
+    ///
+    /// Call this after all cross-contract calls have succeeded to signal
+    /// that no rollback is needed.
+    pub fn finalize(&mut self, env: &Env) {
+        self.compensation_stack = Vec::new(env);
+    }
 }
 
 // -----------------------------------------------------------------------
@@ -195,7 +232,7 @@ pub const FN_CANCEL_SETTLEMENT: Symbol = soroban_sdk::symbol_short!("can_setl");
 mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;
-    use soroban_sdk::{symbol_short, Address, Env};
+    use soroban_sdk::{symbol_short, Address, Env, Vec};
 
     #[test]
     fn test_safe_invoke_unknown_contract_returns_fatal_error() {
@@ -228,9 +265,11 @@ mod tests {
     fn test_safety_tracker_registers_compensation_on_success() {
         let env = Env::default();
         let mut safety = CrossContractSafety::new(&env);
+        let mock_contract = Address::generate(&env);
         // Even though the call will fail (unknown address), we test
         // the registration path via a direct push
         safety.compensation_stack.push_back((
+            mock_contract.clone(),
             FN_LOCK_FUNDS,
             CompensationAction {
                 tag: COMP_UNLOCK_FUNDS,
@@ -296,6 +335,74 @@ mod tests {
                 assert_ne!(fns[i], fns[j]);
             }
         }
+    }
+
+    #[test]
+    fn test_rollback_all_clears_stack() {
+        let env = Env::default();
+        let mut safety = CrossContractSafety::new(&env);
+        let mock_contract = Address::generate(&env);
+
+        safety.compensation_stack.push_back((
+            mock_contract.clone(),
+            FN_LOCK_FUNDS,
+            CompensationAction {
+                tag: COMP_UNLOCK_FUNDS,
+                args: Vec::new(&env),
+            },
+        ));
+        safety.compensation_stack.push_back((
+            mock_contract,
+            FN_RELEASE_PAYMENT,
+            CompensationAction {
+                tag: COMP_REVERSE_SETTLE,
+                args: Vec::new(&env),
+            },
+        ));
+        assert_eq!(safety.depth(), 2);
+
+        safety.rollback_all(&env);
+        assert_eq!(safety.depth(), 0);
+        assert!(!safety.has_pending());
+    }
+
+    #[test]
+    fn test_rollback_all_empty_stack_is_noop() {
+        let env = Env::default();
+        let mut safety = CrossContractSafety::new(&env);
+        safety.rollback_all(&env);
+        assert_eq!(safety.depth(), 0);
+        assert!(!safety.has_pending());
+    }
+
+    #[test]
+    fn test_finalize_clears_stack() {
+        let env = Env::default();
+        let mut safety = CrossContractSafety::new(&env);
+        let mock_contract = Address::generate(&env);
+
+        safety.compensation_stack.push_back((
+            mock_contract,
+            FN_LOCK_FUNDS,
+            CompensationAction {
+                tag: COMP_UNLOCK_FUNDS,
+                args: Vec::new(&env),
+            },
+        ));
+        assert_eq!(safety.depth(), 1);
+
+        safety.finalize(&env);
+        assert_eq!(safety.depth(), 0);
+        assert!(!safety.has_pending());
+    }
+
+    #[test]
+    fn test_finalize_empty_stack_is_noop() {
+        let env = Env::default();
+        let mut safety = CrossContractSafety::new(&env);
+        safety.finalize(&env);
+        assert_eq!(safety.depth(), 0);
+        assert!(!safety.has_pending());
     }
 
     #[test]

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -1131,13 +1131,17 @@ impl SLACalculatorContract {
             }
         }
         if let Some(prev) = existing {
-            // Explicit duplicate policy: same outage_id is idempotent only when
-            // execution inputs resolve to the same deterministic result.
-            if prev.mttr_minutes != mttr_minutes || prev.threshold_minutes != cfg.threshold_minutes
-            {
-                return Err(SLAError::DuplicateOutageInput);
+            if prev.config_version_hash == config_version_hash {
+                // Explicit duplicate policy: same outage_id is idempotent only when
+                // execution inputs resolve to the same deterministic result.
+                if prev.mttr_minutes != mttr_minutes
+                    || prev.threshold_minutes != cfg.threshold_minutes
+                {
+                    return Err(SLAError::DuplicateOutageInput);
+                }
+                return Ok(prev);
             }
-            return Ok(prev);
+            // Config changed: treat as a fresh calculation rather than a conflict.
         }
 
         history.push_back(result.clone());

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -5736,6 +5736,86 @@ fn test_255_duplicate_outage_id_with_different_mttr_panics() {
 }
 
 #[test]
+fn test_config_bumped_duplicate_treated_as_fresh_calculation() {
+    // After set_config changes the config_version_hash, a duplicate outage_id
+    // must be treated as a fresh calculation rather than returning stale cache.
+    let (_env, client, actors) = setup();
+    let outage_id = symbol_short!("CFG_BMP");
+    let severity = symbol_short!("high");
+    let mttr = 10u32;
+
+    let r1 = client.calculate_sla(&actors.operator, &outage_id, &severity, &mttr);
+    let hash1 = r1.config_version_hash;
+
+    // Change reward_base so config_version_hash changes but threshold stays same.
+    // This is the subtle case: old code would return cached result because
+    // threshold and mttr match, ignoring the config change.
+    client.set_config(&actors.admin, &severity, &30, &50, &1500);
+
+    let r2 = client.calculate_sla(&actors.operator, &outage_id, &severity, &mttr);
+    let hash2 = r2.config_version_hash;
+
+    assert_ne!(hash1, hash2);
+    assert_eq!(r2.amount, 3000); // 1500 * 200 / 100 = 3000 (top tier)
+
+    let history = client.get_history();
+    let mut count = 0u32;
+    for i in 0..history.len() {
+        if history.get(i).unwrap().outage_id == outage_id {
+            count += 1;
+        }
+    }
+    assert_eq!(count, 2);
+    assert_eq!(client.get_stats().total_calculations, 2);
+}
+
+#[test]
+fn test_config_bumped_duplicate_threshold_change_is_fresh() {
+    // Config change alters threshold so same mttr flips from met→viol.
+    let (_env, client, actors) = setup();
+    let outage_id = symbol_short!("CFG_THR");
+    let severity = symbol_short!("high");
+
+    let r1 = client.calculate_sla(&actors.operator, &outage_id, &severity, &25);
+    assert_eq!(r1.status, symbol_short!("met"));
+
+    // Lower threshold so the same mttr now violates
+    client.set_config(&actors.admin, &severity, &20, &50, &750);
+
+    let r2 = client.calculate_sla(&actors.operator, &outage_id, &severity, &25);
+    assert_eq!(r2.status, symbol_short!("viol"));
+    assert_eq!(r2.amount, -250);
+
+    assert_eq!(client.get_history().len(), 2);
+    assert_eq!(client.get_stats().total_calculations, 2);
+}
+
+#[test]
+fn test_duplicate_same_config_still_idempotent() {
+    // Without config change, identical duplicate still returns cached result.
+    let (_env, client, actors) = setup();
+    let outage_id = symbol_short!("IDEM_P");
+
+    let r1 = client.calculate_sla(&actors.operator, &outage_id, &symbol_short!("critical"), &5);
+    let r2 = client.calculate_sla(&actors.operator, &outage_id, &symbol_short!("critical"), &5);
+
+    assert_eq!(r1.config_version_hash, r2.config_version_hash);
+    assert_eq!(client.get_history().len(), 1);
+    assert_eq!(client.get_stats().total_calculations, 1);
+}
+
+#[test]
+#[should_panic(expected = "#13")]
+fn test_duplicate_same_config_with_different_mttr_still_panics() {
+    // Without config change, conflicting inputs still reject.
+    let (_env, client, actors) = setup();
+    let outage_id = symbol_short!("CONF");
+
+    client.calculate_sla(&actors.operator, &outage_id, &symbol_short!("high"), &10);
+    client.calculate_sla(&actors.operator, &outage_id, &symbol_short!("high"), &20);
+}
+
+#[test]
 fn test_255_prune_reduces_history_to_keep_latest() {
     // After prune_history(keep=3), exactly 3 entries remain (the most recent).
     let (env, client, actors) = setup();


### PR DESCRIPTION
## Description

Closes #29 

Fix `calculate_sla` duplicate detection to compare `config_version_hash` in addition to `mttr_minutes` and `threshold_minutes`. Previously, submitting a duplicate `outage_id` after a `set_config` change would silently return the stale cached result, ignoring that the config (and therefore the deterministic result) had changed.

The doc comment on the duplicate check promises idempotency only when "execution inputs resolve to the same deterministic result." Since `config_version_hash` is part of those inputs, the comparison must include it to honour the contract invariant.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issues
Relates to #29 

## Changes Made
- **`apexchainx_calculator/src/lib.rs`**: In `calculate_sla`, wrap the existing `mttr_minutes`/`threshold_minutes` duplicate check inside a `config_version_hash` equality guard. If the hashes differ (config was updated), execution falls through to the fresh calculation path — the new result is appended to history, stats are incremented, and events are emitted. If hashes match, the existing logic applies: same inputs → idempotent return, different inputs → `DuplicateOutageInput` error.
- **`apexchainx_calculator/src/tests.rs`**: Added 4 tests:
  - `test_config_bumped_duplicate_treated_as_fresh_calculation` — reward_base changed, same outage_id/mttr/threshold → recalculates with new config, history has 2 entries, stats show 2 calculations
  - `test_config_bumped_duplicate_threshold_change_is_fresh` — threshold lowered, same outage_id/mttr → result flips from met→viol
  - `test_duplicate_same_config_still_idempotent` — no config change → identical duplicate still returns cached result
  - `test_duplicate_same_config_with_different_mttr_still_panics` — same config, different mttr → still errors with `DuplicateOutageInput`

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

All 393 tests pass (3 slow stress tests skipped). `cargo fmt --all --check` and `cargo clippy --all-targets` produce no new warnings.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented complex logic
- [ ] I have updated relevant documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes do not introduce new warnings

## Screenshot (the 4 new added tests)
<img width="1563" height="316" alt="image" src="https://github.com/user-attachments/assets/81d42da6-7588-4994-8752-f6e7d35530e9" />
