### PR TITLE
ci: add cargo-deny job and deny.toml to enforce license, duplicates, …

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,3 +29,19 @@ jobs:
 
       - name: Run cargo audit
         run: cargo audit --manifest-path apexchainx_calculator/Cargo.toml
+
+  deny:
+    name: Dependency Policy (cargo-deny)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Run cargo deny
+        run: cargo deny check --all-features

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,12 @@
+# cargo-deny configuration for ApexChainx-Contracts
+# Policy: allow only MIT, Apache-2.0, ISC; reject semver-duplicate mismatches; reject yanked crates
+
+[checks.licenses]
+allow = ["MIT", "Apache-2.0", "ISC"]
+unknown = "deny"
+
+[checks.duplicates]
+semver = "deny"
+
+[checks.yanked]
+deny = true


### PR DESCRIPTION
closes #40

Problem: The existing CI ([security.yml](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) runs cargo-audit weekly but does not enforce license policies, detect duplicate semver-mismatched crates, or reject yanked crates. This allows transitive dependencies to drift to non-permissive licenses or introduce multiple incompatible copies without CI failure.


What I changed: Added a cargo-deny job to the security workflow and committed a deny.toml policy that:
Licenses: Allows only MIT, Apache-2.0, and ISC (deny unknown/others).
Duplicates: Denies semver-incompatible duplicate crates.
Yanked: Denies yanked crates.
Files changed: deny.toml, [security.yml](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
