### PR TITLE
Fix/bound pause reason

### DIFF
--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -55,6 +55,9 @@ const PAUSED_KEY: Symbol = symbol_short!("PAUSED");
 /// Pause metadata (reason, timestamp, caller). (#66)
 const PAUSE_INFO_KEY: Symbol = symbol_short!("PAUSEINF");
 
+/// Maximum length (in bytes) for the pause reason string. (#68)
+const MAX_REASON_LEN: usize = 256;
+
 /// Cumulative SLA statistics (SLAStats struct). (#29)
 const STATS_KEY: Symbol = symbol_short!("STATS");
 
@@ -247,6 +250,8 @@ pub enum SLAError {
     InvalidPenaltyAmount = 14,
     /// Computed reward amount is invalid (e.g., zero or negative). (SC-W5-046)
     InvalidRewardAmount = 15,
+    /// Input parameter violates documented constraints (e.g., reason too long). (#68)
+    InvalidInput = 16,
 }
 
 // -----------------------------------------------------------------------
@@ -781,6 +786,10 @@ impl SLACalculatorContract {
     pub fn pause(env: Env, caller: Address, reason: String) -> Result<(), SLAError> {
         Self::check_version(&env)?;
         Self::require_admin(&env, &caller)?;
+
+        if reason.len() > MAX_REASON_LEN as u32 {
+            return Err(SLAError::InvalidInput);
+        }
 
         let paused_at = env.ledger().timestamp();
         env.storage().instance().set(&PAUSED_KEY, &true);

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -1919,6 +1919,16 @@ fn test_pause_stores_reason_and_timestamp() {
 }
 
 #[test]
+#[should_panic(expected = "HostError")]
+fn test_pause_rejects_long_reason() {
+    let (env, client, actors) = setup();
+    // 257-byte reason exceeds MAX_REASON_LEN (256)
+    let long_reason =
+        soroban_sdk::String::from_str(&env, &"A".repeat(257));
+    client.pause(&actors.admin, &long_reason);
+}
+
+#[test]
 fn test_unpause_clears_pause_info() {
     let (env, client, actors) = setup();
     client.pause(

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -1919,7 +1919,7 @@ fn test_pause_stores_reason_and_timestamp() {
 }
 
 #[test]
-#[should_panic(expected = "HostError")]
+#[should_panic(expected = "#16")]
 fn test_pause_rejects_long_reason() {
     let (env, client, actors) = setup();
     // 257-byte reason exceeds MAX_REASON_LEN (256)

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -1923,8 +1923,7 @@ fn test_pause_stores_reason_and_timestamp() {
 fn test_pause_rejects_long_reason() {
     let (env, client, actors) = setup();
     // 257-byte reason exceeds MAX_REASON_LEN (256)
-    let long_reason =
-        soroban_sdk::String::from_str(&env, &"A".repeat(257));
+    let long_reason = soroban_sdk::String::from_str(&env, &"A".repeat(257));
     client.pause(&actors.admin, &long_reason);
 }
 


### PR DESCRIPTION
Closes #31 

Here's a summary of what was done:

**Changes in `apexchainx_calculator/src/lib.rs`:**
- Added `MAX_REASON_LEN = 256` constant at line 59
- Added `SLAError::InvalidInput = 16` variant at line 254
- Added reason length check in `pause()` at lines 790-792 — returns `Err(SLAError::InvalidInput)` if `reason.len() > 256`

**Changes in `apexchainx_calculator/src/tests.rs`:**
- Added `test_pause_rejects_long_reason` test at line 1922 — verifies that a 257-byte reason triggers a `HostError`

**2 commits created:**
1. `af6559c` — `feat: bound pause reason to 256 bytes with SLAError::InvalidInput (#68)`
2. `85ea71b` — `test: add test_pause_rejects_long_reason for reason >256 bytes (#68)`

Note: `cargo build` and `cargo check --tests` pass. The test binary cannot link on this Windows GNU environment due to a pre-existing `backtrace` crate dlltool incompatibility (unrelated to these changes).
