### PR TITLE
test: add proptest fuzz tests for compute_result() (#calculator-fuzz-…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,34 @@ jobs:
         working-directory: apexchainx_calculator
         run: cargo test --lib
 
+  fuzz-tests:
+    name: Fuzz Tests (proptest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.94.1
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apexchainx_calculator/target
+          key: fuzz-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            fuzz-${{ runner.os }}-cargo-
+
+      - name: Run property-based fuzz tests
+        working-directory: apexchainx_calculator
+        run: cargo test --lib fuzz_tests::
+
+
   provenance-hashes:
     name: Provenance & Hashes
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Rust
 target/
+proptest-regressions/
+
 
 # Soroban
 test_snapshots/

--- a/apexchainx_calculator/Cargo.toml
+++ b/apexchainx_calculator/Cargo.toml
@@ -17,4 +17,6 @@ default = []
 soroban-sdk = { version = "21.1.0", features = ["alloc"] }
 
 [dev-dependencies]
+proptest = "1.5.0"
 soroban-sdk = { version = "21.1.0", features = ["testutils", "alloc"] }
+

--- a/apexchainx_calculator/src/fuzz_tests.rs
+++ b/apexchainx_calculator/src/fuzz_tests.rs
@@ -1,0 +1,190 @@
+#![cfg(test)]
+
+use crate::{SLACalculatorContract, SLAConfig};
+use soroban_sdk::{symbol_short, Env, Symbol};
+use proptest::prelude::*;
+
+// Helper to check if a config is valid for a given severity.
+fn is_config_valid(
+    severity: &Symbol,
+    threshold_minutes: u32,
+    penalty_per_minute: i128,
+    reward_base: i128,
+) -> bool {
+    SLACalculatorContract::validate_config(
+        severity,
+        threshold_minutes,
+        penalty_per_minute,
+        reward_base,
+    )
+    .is_ok()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1000))]
+
+    #[test]
+    fn test_fuzz_compute_result_invariants(
+        mttr in 0..u32::MAX,
+        severity_idx in 0..4u8,
+        threshold_minutes in 0..2000u32,
+        penalty_per_minute in -100..20000i128,
+        reward_base in -100..200000i128,
+    ) {
+        let _env = Env::default();
+        let severity = match severity_idx {
+            0 => symbol_short!("critical"),
+            1 => symbol_short!("high"),
+            2 => symbol_short!("medium"),
+            _ => symbol_short!("low"),
+        };
+
+        let valid = is_config_valid(&severity, threshold_minutes, penalty_per_minute, reward_base);
+
+        if valid {
+            let cfg = SLAConfig {
+                threshold_minutes,
+                penalty_per_minute,
+                reward_base,
+            };
+
+            let res_result = SLACalculatorContract::compute_result(
+                symbol_short!("outage"),
+                mttr,
+                &cfg,
+                0,
+                0,
+            );
+
+            // If config is valid under validate_config, compute_result should always succeed
+            // and satisfy the invariants.
+            let res = res_result.expect("Valid configuration must succeed computing SLA result");
+
+            assert_eq!(res.outage_id, symbol_short!("outage"));
+            assert_eq!(res.threshold_minutes, threshold_minutes);
+
+            if mttr <= threshold_minutes {
+                // Case 2: SLA met -> reward
+                assert_eq!(res.status, symbol_short!("met"));
+                assert_eq!(res.payment_type, symbol_short!("rew"));
+                assert!(res.amount > 0, "Reward amount must be positive, got {}", res.amount);
+
+                // Reward scaling check
+                // base * multiplier / 100
+                // multiplier is 200, 150, or 100
+                let performance_ratio = (mttr * 100).checked_div(threshold_minutes).unwrap_or(0);
+                let expected_multiplier = if performance_ratio < 50 {
+                    200u32
+                } else if performance_ratio < 75 {
+                    150u32
+                } else {
+                    100u32
+                };
+                let expected_reward = reward_base
+                    .saturating_mul(expected_multiplier as i128)
+                    .div_euclid(100);
+                assert_eq!(res.amount, expected_reward);
+
+                // Rating check
+                let expected_rating = if performance_ratio < 50 {
+                    symbol_short!("top")
+                } else if performance_ratio < 75 {
+                    symbol_short!("excel")
+                } else {
+                    symbol_short!("good")
+                };
+                assert_eq!(res.rating, expected_rating);
+            } else {
+                // Case 1: SLA violated -> penalty
+                assert_eq!(res.status, symbol_short!("viol"));
+                assert_eq!(res.payment_type, symbol_short!("pen"));
+                assert!(res.amount < 0, "Penalty amount must be negative, got {}", res.amount);
+                assert_eq!(res.rating, symbol_short!("poor"));
+
+                let overtime = (mttr - threshold_minutes) as i128;
+                let expected_penalty = overtime.saturating_mul(penalty_per_minute);
+                assert_eq!(res.amount, -expected_penalty);
+            }
+        }
+    }
+
+    #[test]
+    fn test_fuzz_compute_result_monotonicity(
+        mttr1 in 0..u32::MAX,
+        delta in 1..200000u32, // delta > 0
+        severity_idx in 0..4u8,
+        threshold_minutes in 0..2000u32,
+        penalty_per_minute in -100..20000i128,
+        reward_base in -100..200000i128,
+    ) {
+        let mttr2 = mttr1.saturating_add(delta);
+        if mttr1 == mttr2 {
+            return Ok(()); // avoid saturated values where mttr1 == mttr2
+        }
+
+        let _env = Env::default();
+        let severity = match severity_idx {
+            0 => symbol_short!("critical"),
+            1 => symbol_short!("high"),
+            2 => symbol_short!("medium"),
+            _ => symbol_short!("low"),
+        };
+
+        let valid = is_config_valid(&severity, threshold_minutes, penalty_per_minute, reward_base);
+
+        if valid {
+            let cfg = SLAConfig {
+                threshold_minutes,
+                penalty_per_minute,
+                reward_base,
+            };
+
+            let res1 = SLACalculatorContract::compute_result(
+                symbol_short!("outage"),
+                mttr1,
+                &cfg,
+                0,
+                0,
+            );
+            let res2 = SLACalculatorContract::compute_result(
+                symbol_short!("outage"),
+                mttr2,
+                &cfg,
+                0,
+                0,
+            );
+
+            if let (Ok(r1), Ok(r2)) = (res1, res2) {
+                assert!(
+                    r1.amount >= r2.amount,
+                    "Monotonicity violated: amount for mttr1={} is {}, but for mttr2={} is {} (cfg threshold={}, penalty={}, reward={})",
+                    mttr1, r1.amount, mttr2, r2.amount, threshold_minutes, penalty_per_minute, reward_base
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_fuzz_compute_result_no_panic(
+        mttr in 0..u32::MAX,
+        threshold_minutes in 0..u32::MAX,
+        penalty_per_minute in i128::MIN..=i128::MAX,
+        reward_base in i128::MIN..=i128::MAX,
+    ) {
+        let _env = Env::default();
+        let cfg = SLAConfig {
+            threshold_minutes,
+            penalty_per_minute,
+            reward_base,
+        };
+
+        // This call must not panic under any circumstances.
+        let _ = SLACalculatorContract::compute_result(
+            symbol_short!("outage"),
+            mttr,
+            &cfg,
+            0,
+            0,
+        );
+    }
+}

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -12,6 +12,9 @@ pub struct SLACalculatorContract;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod fuzz_tests;
+
 pub mod config_bundle;
 pub mod config_metadata;
 pub mod coordination_harness;
@@ -1210,7 +1213,10 @@ impl SLACalculatorContract {
         if mttr_minutes > threshold {
             let overtime = (mttr_minutes - threshold) as i128;
             let penalty = overtime.saturating_mul(cfg.penalty_per_minute);
-            let amount = -penalty;
+            let amount = match penalty.checked_neg() {
+                Some(val) => val,
+                None => return Err(SLAError::InvalidPenaltyAmount),
+            };
             if amount >= 0 {
                 return Err(SLAError::InvalidPenaltyAmount);
             }
@@ -1228,7 +1234,7 @@ impl SLACalculatorContract {
             })
         } else {
             // Case 2: SLA met → reward
-            let performance_ratio = (mttr_minutes * 100).checked_div(threshold).unwrap_or(0);
+            let performance_ratio = (mttr_minutes as u64 * 100).checked_div(threshold as u64).unwrap_or(0);
 
             let (multiplier, rating) = if performance_ratio < 50 {
                 (200u32, symbol_short!("top"))


### PR DESCRIPTION
## Description

Adds property-based fuzz testing using `proptest` to the `apexchainx_calculator` crate.
The fuzzer immediately discovered two real overflow panics in `compute_result()` that were
undetected by the existing 400+ hand-crafted tests — both are fixed in this PR.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issues
Relates to: **No fuzz testing exists. All tests use hand-crafted inputs.**

## Changes Made
- Added `proptest = "1.5.0"` as a dev-dependency in `apexchainx_calculator/Cargo.toml`
- Created `apexchainx_calculator/src/fuzz_tests.rs` with three property-based tests covering `compute_result()` across `0..u32::MAX` MTTR input space
- Fixed **negation overflow** panic in `compute_result()`: replaced bare `-penalty` with `checked_neg()` — `i128::MIN` negation previously caused an unconditional panic
- Fixed **multiplication overflow** panic in `compute_result()`: widened `mttr_minutes * 100` from `u32` to `u64` arithmetic — any MTTR above ~42.9M previously panicked
- Added dedicated `fuzz-tests` CI job in `.github/workflows/ci.yml` with a `timeout-minutes: 2` guard
- Added `proptest-regressions/` to `.gitignore`

## Testing

### Property tests added (`fuzz_tests.rs`)

| Test | What it verifies |
|------|-----------------|
| `test_fuzz_compute_result_invariants` | For any MTTR in `0..u32::MAX` with a valid config: `status == "met"` iff `mttr <= threshold`, reward `> 0` for met, penalty `< 0` for violated, exact amount and rating values |
| `test_fuzz_compute_result_monotonicity` | `amount(mttr1) >= amount(mttr2)` whenever `mttr1 < mttr2` — increasing MTTR never improves the financial outcome |
| `test_fuzz_compute_result_no_panic` | Fuzzes all parameters including extreme `i128::MIN / i128::MAX` values — zero panics under any input |

### Results (1,000 cases per property)

Closes #10 
