### PR TITLE
feat: add workflow secret-leak check (#122)

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,48 @@
+# =============================================================================
+# ApexChainx Contracts — Workflow Secret Lint (issue #122)
+# =============================================================================
+#
+# Static check that no workflow writes secret material into the build log.
+# GitHub Actions masks known secret values, but masking is best-effort: it
+# breaks on transformed values (base64, substrings, JSON-encoded) and does
+# nothing about a full environment dump. The cheapest defence is to never print
+# the secret at all — this lints the workflow YAML for the patterns that do and
+# fails CI on a hit.
+#
+# Kept as its own workflow (rather than a step in ci.yml) so it needs no Rust
+# toolchain, runs in seconds, and reports independently of the contract build.
+#
+# Run locally:  npx --yes tsx tools/secret-leak-check.ts
+# =============================================================================
+
+name: Workflow Secret Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: workflow-secret-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  secret-leak-check:
+    name: Secret Leak Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check workflows never echo secrets
+        run: npx --yes tsx tools/secret-leak-check.ts

--- a/tools/secret-leak-check.ts
+++ b/tools/secret-leak-check.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env ts-node
+/**
+ * Issue #122 — Static check that CI workflows never echo secrets.
+ *
+ * GitHub Actions masks known secret values in logs, but masking is best-effort:
+ * it breaks on transformed values (base64, substrings, JSON-encoded) and does
+ * nothing for a full environment dump. The cheapest defence is to never write
+ * secret material to the log in the first place. This lints the workflow YAML
+ * for the patterns that do so and fails CI on a hit.
+ *
+ * Rules:
+ *   echo-secrets  `echo`/`printf` of a `${{ secrets.* }}` expression.
+ *   env-dump      a bare `env` / `printenv` shell command, which prints every
+ *                 variable — including any secret mapped in via `env:`.
+ *   echo-secret-env  `echo`/`printf` of a shell variable that the same step
+ *                 mapped from `${{ secrets.* }}` (the indirect leak).
+ *
+ * Usage:
+ *   npx --yes tsx tools/secret-leak-check.ts
+ *   npx --yes ts-node --transpile-only tools/secret-leak-check.ts
+ *   npx --yes tsx tools/secret-leak-check.ts --dir .github/workflows
+ *
+ * Suppress a reviewed false positive with an inline comment on the same line:
+ *   run: echo "not a secret"   # secret-leak-check:allow explain why
+ *
+ * Exit codes: 0 = clean, 1 = at least one finding.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ALLOW_MARKER = 'secret-leak-check:allow';
+const DEFAULT_DIR = path.join('.github', 'workflows');
+
+interface Rule {
+  id: string;
+  reason: string;
+  test: (line: string) => boolean;
+}
+
+/** `${{ secrets.NAME }}` — tolerant of spacing. */
+const SECRETS_EXPR = /\$\{\{\s*secrets\.[A-Za-z_][A-Za-z0-9_]*\s*\}\}/;
+const ECHOES = /\b(echo|printf)\b/;
+
+const RULES: Rule[] = [
+  {
+    id: 'echo-secrets',
+    reason: 'echo/printf of a ${{ secrets.* }} expression writes the secret into the build log',
+    test: (line) => ECHOES.test(line) && SECRETS_EXPR.test(line),
+  },
+  {
+    id: 'env-dump',
+    // Only a bare `env` / `printenv` COMMAND. Never the YAML `env:` mapping key,
+    // which is legitimate and common — hence the trailing-colon exclusion.
+    reason: 'a bare `env`/`printenv` dumps every variable, including secrets mapped via env:',
+    test: (line) => {
+      const s = stripRunPrefix(line).trim();
+      if (s.endsWith(':')) return false; // `env:` YAML key
+      return /^(env|printenv)(\s*(\||>|>>|&&|;).*)?$/.test(s);
+    },
+  },
+];
+
+/** `run: env` → `env`, so a one-line run step is checked like a script line. */
+function stripRunPrefix(line: string): string {
+  const m = line.match(/^\s*-?\s*run:\s*(.*)$/);
+  return m ? m[1] : line;
+}
+
+/** Shell variables the step mapped from a secret, e.g. `TOKEN: ${{ secrets.T }}`. */
+function collectSecretEnvVars(lines: string[]): Set<string> {
+  const names = new Set<string>();
+  for (const line of lines) {
+    const m = line.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.*)$/);
+    if (m && SECRETS_EXPR.test(m[2])) names.add(m[1]);
+  }
+  return names;
+}
+
+/** echo of a secret-derived variable: `echo $TOKEN` / `echo "${TOKEN}"`. */
+function echoesSecretVar(line: string, secretVars: Set<string>): string | null {
+  if (!ECHOES.test(line)) return null;
+  for (const name of secretVars) {
+    const ref = new RegExp('\\$\\{?' + name + '\\b');
+    if (ref.test(line)) return name;
+  }
+  return null;
+}
+
+function listWorkflowFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir)
+    .filter((f: string) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .map((f: string) => path.join(dir, f))
+    .sort();
+}
+
+function main(): void {
+  const dirArg = process.argv.indexOf('--dir');
+  const dir = dirArg !== -1 ? process.argv[dirArg + 1] : DEFAULT_DIR;
+
+  const files = listWorkflowFiles(dir);
+  if (files.length === 0) {
+    console.error(`secret-leak-check: no workflow files found in ${dir}`);
+    process.exit(1);
+  }
+
+  const findings: string[] = [];
+
+  for (const file of files) {
+    const lines: string[] = fs.readFileSync(file, 'utf8').split('\n');
+    const secretVars = collectSecretEnvVars(lines);
+
+    lines.forEach((line: string, i: number) => {
+      if (line.includes(ALLOW_MARKER)) return;
+
+      for (const rule of RULES) {
+        if (rule.test(line)) {
+          findings.push(`${file}:${i + 1}  [${rule.id}] ${rule.reason}\n    ${line.trim()}`);
+          return;
+        }
+      }
+
+      const leaked = echoesSecretVar(line, secretVars);
+      if (leaked) {
+        findings.push(
+          `${file}:${i + 1}  [echo-secret-env] echoes $${leaked}, which this workflow maps from ${'${{ secrets.* }}'}\n    ${line.trim()}`,
+        );
+      }
+    });
+  }
+
+  console.log(`secret-leak-check: scanned ${files.length} workflow file(s) in ${dir}`);
+
+  if (findings.length > 0) {
+    console.error(`\n✗ ${findings.length} potential secret leak(s):\n`);
+    findings.forEach((f) => console.error(`  ${f}\n`));
+    console.error(
+      `Do not print secrets to the build log. Pass them directly to the command that needs\n` +
+        `them, or use a file/masked input. If a hit is a reviewed false positive, append\n` +
+        `\`# ${ALLOW_MARKER} <reason>\` to that line.`,
+    );
+    process.exit(1);
+  }
+
+  console.log('✓ no secret-leaking patterns found');
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## Summary

Closes #122. Adds a static lint so workflow YAML can never print secret material into the build log, and fails CI on a hit.

GitHub Actions masks known secret values, but masking is best-effort — it breaks on transformed values (base64, substrings, JSON-encoded) and does nothing about a full environment dump. The cheapest defence is to never print the secret at all.

## Files

**`tools/secret-leak-check.ts`** (new) — scans `.github/workflows/*.yml|yaml`, exits non-zero on a hit. Follows the existing `tools/` conventions (`ts-node` shebang, CommonJS, usage header).

| Rule | Catches |
|---|---|
| `echo-secrets` | `echo`/`printf` of a `${{ secrets.* }}` expression |
| `env-dump` | a bare `env` / `printenv` shell command |
| `echo-secret-env` | `echo`/`printf` of a shell var the same workflow mapped from `${{ secrets.* }}` (the indirect leak) |

A reviewed false positive can be suppressed inline: `# secret-leak-check:allow <reason>`.

**`.github/workflows/workflow-lint.yml`** (new) — runs it on every push/PR to `main`.

## Two decisions worth flagging

1. **`env:` vs `env`.** The `env:` YAML mapping key is legitimate and everywhere, so the `env-dump` rule only matches `env`/`printenv` as a *shell command* and explicitly excludes anything ending in `:`. Without that, the rule would false-positive across the whole repo.

2. **Own workflow instead of a step in `ci.yml`.** I initially wired this into `ci.yml`, then found **`ci.yml` currently fails to parse as YAML** — line 119, `run: cargo test --lib fuzz_tests::` (both `js-yaml` and Ruby `psych` reject it; GitHub lists those runs as `.github/workflows/ci.yml` rather than `name: CI`, which is what it shows when it can't parse the file). A step added there would never run, so the lint lives in its own workflow — which also means no Rust toolchain and a seconds-long job. **This PR does not touch `ci.yml`** (that parse bug looks like a separate issue worth its own fix — happy to open one).

## Testing

- **Passes clean on this repo as-is:** 4 workflow files scanned, 0 findings, exit 0 — including its own new workflow.
- **Negative fixture** (direct secret echo, `env`, `printenv | grep`, indirect secret-derived echo) → exactly **4 findings, exit 1**.
- **No false positives:** an allowlisted line, the legitimate `env:` blocks, and a plain `echo "building"` are all correctly ignored.
- `workflow-lint.yml` validated as YAML 1.2.

Happy to adjust the rule set, add more patterns, or fold it into `ci.yml` instead once that file parses.
