### PR TITLE
feat: add justfile for common commands (#113)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,93 @@
+# =============================================================================
+# ApexChainx Contracts — common developer commands (issue #113)
+# =============================================================================
+#
+# One-liners for the sequences that CI runs, so a contributor can reproduce a
+# CI failure locally without reading the workflow YAML. Every cargo recipe
+# mirrors the matching step in .github/workflows/ci.yml (noted per recipe) and
+# runs in the contract crate, which is CI's `working-directory`.
+#
+# Install just:  brew install just  |  cargo install just  |  https://just.systems
+# Usage:         just <recipe>      |  `just` on its own lists every recipe.
+# =============================================================================
+
+# Contract crate — matches `working-directory: apexchainx_calculator` in CI.
+crate := "apexchainx_calculator"
+wasm_target := "wasm32-unknown-unknown"
+
+# List available recipes.
+default:
+    @just --list
+
+# ---------------------------------------------------------------- test ------
+
+# Run the library test suite.            [CI: E2E Tests]
+test:
+    cd {{crate}} && cargo test --lib
+
+# Run the property-based fuzz tests.     [CI: Fuzz Tests (proptest)]
+fuzz:
+    cd {{crate}} && cargo test --lib fuzz_tests::
+
+# ---------------------------------------------------------------- lint ------
+
+# Format the crate in place.
+fmt:
+    cd {{crate}} && cargo fmt
+
+# Verify formatting without writing.     [CI: Format check]
+fmt-check:
+    cd {{crate}} && cargo fmt --check
+
+# Clippy with warnings denied.           [CI: Clippy]
+lint:
+    cd {{crate}} && cargo clippy --all-targets -- -D warnings
+
+# Type-check the crate.                  [CI: Cargo check]
+check:
+    cd {{crate}} && cargo check
+
+# --------------------------------------------------------------- build ------
+
+# Build natively.                        [CI: Build native]
+build:
+    cd {{crate}} && cargo build
+
+# Build the WASM contract.               [CI: Build WASM]
+wasm:
+    cd {{crate}} && cargo build --target {{wasm_target}}
+
+# Build the release WASM.                [CI: Provenance & Hashes]
+wasm-release:
+    cd {{crate}} && cargo build --target {{wasm_target}} --release
+
+# Assert no_std compliance for wasm32.   [CI: WASM no-std compliance check]
+no-std:
+    cd {{crate}} && cargo check --target {{wasm_target}} --lib
+
+# sha256 of the release WASM.            [CI: Generate hash]
+hash: wasm-release
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Workspace build — artifacts land in the ROOT target/, not {{crate}}/target/.
+    wasm="target/{{wasm_target}}/release/{{crate}}.wasm"
+    if [ ! -f "$wasm" ]; then
+        echo "WASM file not found at $wasm" >&2
+        exit 1
+    fi
+    # sha256sum on Linux/CI, shasum on macOS.
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$wasm" | awk '{print $1 "  {{crate}}.wasm"}'
+    else
+        shasum -a 256 "$wasm" | awk '{print $1 "  {{crate}}.wasm"}'
+    fi
+
+# ----------------------------------------------------------------- all ------
+
+# Remove build artifacts.
+clean:
+    cd {{crate}} && cargo clean
+
+# Everything CI gates on, in CI's order. Run before opening a PR.
+ci: fmt-check lint check no-std test fuzz wasm
+    @echo "✓ local CI equivalent passed"


### PR DESCRIPTION
## Summary

Closes #113. Adds a `justfile` so the common sequences are one-liners and a contributor can reproduce CI locally without reading the workflow YAML.

`just` on its own lists every recipe. All cargo recipes run in `apexchainx_calculator` (matching CI's `working-directory`), and each recipe's doc comment names the CI job it mirrors.

## CI parity

| Recipe | Command | Mirrors CI job |
|---|---|---|
| `just test` | `cargo test --lib` | E2E Tests |
| `just fuzz` | `cargo test --lib fuzz_tests::` | Fuzz Tests (proptest) |
| `just fmt` / `fmt-check` | `cargo fmt` / `--check` | Format check |
| `just lint` | `cargo clippy --all-targets -- -D warnings` | Clippy |
| `just check` | `cargo check` | Cargo check |
| `just build` | `cargo build` | Build native |
| `just wasm` | `cargo build --target wasm32-unknown-unknown` | Build WASM |
| `just wasm-release` | `… --release` | Provenance & Hashes |
| `just no-std` | `cargo check --target wasm32-unknown-unknown --lib` | WASM no-std compliance |
| `just hash` | sha256 of the release WASM | Generate hash |

Plus `just clean` and `just ci` — the whole gate in CI's order, for a pre-PR check.

## Testing

Each recipe was **run**, not just written:

- `just test` → **425 passed**
- `just fuzz` → **3 passed, 422 filtered** (confirms the `fuzz_tests::` filter)
- `just lint` → clippy clean · `just check`, `just no-std`, `just wasm` → all succeed
- `just hash` → emits the same `<sha256>  apexchainx_calculator.wasm` line as the CI step

Two findings worth passing on (both **pre-existing, and deliberately not "fixed" here** — happy to open separate issues):

1. **`just fmt-check` currently fails** — `cargo fmt --check` reports a diff in `apexchainx_calculator/src/fuzz_tests.rs`. The recipe is faithfully reproducing CI's Format check; the formatting has simply drifted. (Plausibly unnoticed because of point 2.)
2. **`.github/workflows/ci.yml` doesn't parse as YAML** — line 119, `run: cargo test --lib fuzz_tests::` (both `js-yaml` and Ruby `psych` reject it; GitHub lists those runs as `.github/workflows/ci.yml` rather than `name: CI`, which is what it shows when a workflow file can't be parsed). That's why this PR **doesn't** wire `just` into CI: a change there wouldn't run. Once it parses, swapping the CI steps to `just <recipe>` is a small follow-up I'm glad to do.

`just` install: `brew install just` / `cargo install just`.
