### PR TITLE
feat: publish migrate_done event upon successful storage migration an…

### DIFF
--- a/apexchainx_calculator/scratch_test.rs
+++ b/apexchainx_calculator/scratch_test.rs
@@ -1,0 +1,5 @@
+use soroban_sdk::{Env, Symbol};
+
+pub fn test_sym(env: &Env) -> Symbol {
+    Symbol::new(env, "migrate_done")
+}

--- a/apexchainx_calculator/src/event_schema.rs
+++ b/apexchainx_calculator/src/event_schema.rs
@@ -102,6 +102,11 @@
 //! - topic[2]: caller Address
 //! - payload:  ()
 //!
+//! ## migrate_done (`migrate_done`)
+//! Emitted when a storage migration completes successfully.
+//! - topic[2]: caller Address
+//! - payload:  (old_version: u32, new_version: u32)
+//!
 //! # Schema Versioning
 //!
 //! Breaking changes (field removal, type changes, reordering) MUST increment
@@ -134,6 +139,7 @@ pub const EVENT_OP_ACC: Symbol = symbol_short!("op_acc");
 pub const EVENT_OP_CAN: Symbol = symbol_short!("op_can");
 pub const EVENT_CONFIG_FREEZE: Symbol = symbol_short!("cfg_frz");
 pub const EVENT_CONFIG_UNFREEZE: Symbol = symbol_short!("cfg_unfrz");
+pub const EVENT_MIGRATE_DONE: &str = "migrate_done";
 
 /// Returns the canonical event version string for consumer documentation.
 pub fn current_event_version() -> Symbol {

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -691,6 +691,15 @@ impl SLACalculatorContract {
             return Err(SLAError::VersionMismatch);
         }
 
+        env.events().publish(
+            (
+                soroban_sdk::Symbol::new(&env, event_schema::EVENT_MIGRATE_DONE),
+                event_schema::EVENT_VERSION,
+                caller,
+            ),
+            (stored, current),
+        );
+
         Ok(())
     }
 

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -1716,6 +1716,50 @@ fn test_get_contract_metadata_is_deterministic() {
 // ============================================================
 
 #[test]
+
+#[test]
+fn test_migrate_done_symbol() {
+    let env = Env::default();
+    let _sym = soroban_sdk::Symbol::new(&env, "migrate_done");
+}
+
+
+#[test]
+fn test_migrate_emits_migrate_done_event() {
+    let (env, client, actors) = setup();
+
+    // Force storage version to 0 to trigger a real migration
+    let zero: u32 = 0;
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&symbol_short!("VER"), &zero);
+    });
+
+    client.migrate(&actors.admin);
+
+    let events = env.events().all();
+    let mut found = false;
+    for event in events.iter() {
+        let (contract_id, topic_tuple, payload) = event;
+        if contract_id != client.address {
+            continue;
+        }
+
+        let topic0: soroban_sdk::Symbol = topic_tuple.get(0).unwrap().try_into_val(&env).unwrap();
+        if topic0 == soroban_sdk::Symbol::new(&env, "migrate_done") {
+            found = true;
+            let topic1: soroban_sdk::Symbol = topic_tuple.get(1).unwrap().try_into_val(&env).unwrap();
+            assert_eq!(topic1, soroban_sdk::symbol_short!("v1"));
+
+            let topic2: soroban_sdk::Address = topic_tuple.get(2).unwrap().try_into_val(&env).unwrap();
+            assert_eq!(topic2, actors.admin);
+
+            let payload_tuple: (u32, u32) = payload.try_into_val(&env).unwrap();
+            assert_eq!(payload_tuple, (0, 1));
+        }
+    }
+    assert!(found, "migrate_done event not found");
+}
+
 fn test_migrate_is_idempotent_when_already_current() {
     let (_env, client, actors) = setup();
     // Already at v1 – migrate should succeed without error


### PR DESCRIPTION
closes #118 

Description
Problem: The migrate() function was silently mutating state during contract upgrades. Without a deterministic event emitted upon a successful migration, off-chain backend consumers were unable to track, correlate, or react to storage upgrades.

Solution: This PR introduces the migrate_done event, which is emitted successfully at the end of the migrate() function when a storage upgrade occurs. This creates an auditable, versioned trail for backends to trace.

Changes Made
apexchainx_calculator/src/event_schema.rs:
Added schema documentation for the new migrate_done event.
Exposed EVENT_MIGRATE_DONE as a &str constant (since the 12-character name exceeds the symbol_short! 9-character limit).
apexchainx_calculator/src/lib.rs:
Updated the migrate() function to publish the migrate_done event right after the successful migration sanity checks.
The event adheres to the standard canonical event schema:
topic[0]: "migrate_done"
topic[1]: "v1" (Canonical Event Version)
topic[2]: caller
payload: (old_version, new_version)
apexchainx_calculator/src/tests.rs:
Added a new test test_migrate_emits_migrate_done_event to explicitly verify that triggering a storage migration correctly emits the event and encodes the topic/payload constraints accurately.