### PR TITLE
chore: add markdown link checker

### DIFF
--- a/tools/link-check.test.ts
+++ b/tools/link-check.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { checkLinksInFile, extractLocalLinks } from "./link-check.ts";
+
+test("extractLocalLinks ignores external and anchor links", () => {
+  const markdown = "See [Code of Conduct](CODE_OF_CONDUCT.md), [docs](./docs/PROJECT_CONTEXT.md), [section](#section), and [external](https://example.com).";
+  assert.deepEqual(extractLocalLinks(markdown), ["CODE_OF_CONDUCT.md", "./docs/PROJECT_CONTEXT.md"]);
+});
+
+test("checkLinksInFile reports missing targets", () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "link-check-"));
+  const filePath = path.join(tempDir, "CONTRIBUTING.md");
+  writeFileSync(filePath, "See [ok](./ok.txt) and [missing](./missing.txt).\n");
+  writeFileSync(path.join(tempDir, "ok.txt"), "ok\n");
+
+  try {
+    const result = checkLinksInFile(filePath);
+    assert.equal(result.missing.length, 1);
+    assert.equal(result.missing[0]?.target, "./missing.txt");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("checkLinksInFile resolves the repository contributing guide", () => {
+  const result = checkLinksInFile(path.resolve("CONTRIBUTING.md"));
+  assert.equal(result.missing.length, 0);
+});

--- a/tools/link-check.ts
+++ b/tools/link-check.ts
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync } from "fs";
+import path from "path";
+
+export interface LinkCheckResult {
+  checkedFile: string;
+  links: string[];
+  missing: Array<{ target: string; resolvedPath: string }>;
+}
+
+function isExternalReference(target: string): boolean {
+  if (!target || target.startsWith("#")) {
+    return true;
+  }
+
+  if (target.startsWith("//")) {
+    return true;
+  }
+
+  return /^(?:[a-z]+:|\/\/)/i.test(target);
+}
+
+export function extractLocalLinks(markdown: string): string[] {
+  const links: string[] = [];
+  const pattern = /(?<!!)\[([^\]]+)\]\(([^)]+)\)/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(markdown)) !== null) {
+    const rawTarget = match[2].trim();
+    const target = rawTarget.split(/\s+/)[0].replace(/^<|>$/g, "");
+
+    if (!isExternalReference(target)) {
+      links.push(target);
+    }
+  }
+
+  return links;
+}
+
+export function checkLinksInFile(markdownFilePath: string): LinkCheckResult {
+  const absolutePath = path.resolve(markdownFilePath);
+  const markdown = readFileSync(absolutePath, "utf8");
+  const links = extractLocalLinks(markdown);
+  const missing = links
+    .map((target) => {
+      const [targetPath] = target.split("#");
+      const cleanedTarget = targetPath.split("?")[0];
+
+      if (!cleanedTarget) {
+        return null;
+      }
+
+      const resolvedPath = path.resolve(path.dirname(absolutePath), cleanedTarget);
+      return existsSync(resolvedPath)
+        ? null
+        : { target, resolvedPath };
+    })
+    .filter((entry): entry is { target: string; resolvedPath: string } => entry !== null);
+
+  return { checkedFile: absolutePath, links, missing };
+}
+
+export function main(args: string[] = process.argv.slice(2)): void {
+  const targetArg = args[0] ? path.resolve(process.cwd(), args[0]) : path.resolve(process.cwd(), "CONTRIBUTING.md");
+  const result = checkLinksInFile(targetArg);
+
+  if (result.missing.length > 0) {
+    console.error(`Broken links found in ${path.relative(process.cwd(), result.checkedFile)}:`);
+    for (const entry of result.missing) {
+      console.error(`- ${entry.target} -> ${entry.resolvedPath}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`Checked ${result.links.length} local reference(s) in ${path.relative(process.cwd(), result.checkedFile)}; all resolved successfully.`);
+}
+
+if (process.argv[1] && process.argv[1].endsWith("link-check.ts")) {
+  main();
+}


### PR DESCRIPTION
closes #114



PR Description
This PR adds a lightweight markdown link validator for the repository’s contributing docs.

What changed
Added a new script at link-check.ts to check local markdown links referenced from CONTRIBUTING.md
Added regression tests at link-check.test.ts to cover:
local link extraction
missing-link detection
validation of the repository contributing guide
Why
The repository previously referenced CONTRIBUTING.md links without any automated validation, which could allow broken local references to slip in unnoticed.

Verification
The following commands were run successfully:

npx --yes tsx link-check.ts CONTRIBUTING.md
npx --yes tsx --test tools/link-check.test.ts