### PR TITLE
refactor: introduce error_responses module to standardize SLAError ch…

### DIFF
--- a/apexchainx_calculator/src/error_responses.rs
+++ b/apexchainx_calculator/src/error_responses.rs
@@ -1,0 +1,69 @@
+use crate::SLAError;
+
+pub fn is_already_initialized(err: &SLAError) -> bool {
+    matches!(err, SLAError::AlreadyInitialized)
+}
+
+pub fn is_not_initialized(err: &SLAError) -> bool {
+    matches!(err, SLAError::NotInitialized)
+}
+
+pub fn is_unauthorized(err: &SLAError) -> bool {
+    matches!(err, SLAError::Unauthorized)
+}
+
+pub fn is_config_not_found(err: &SLAError) -> bool {
+    matches!(err, SLAError::ConfigNotFound)
+}
+
+pub fn is_version_mismatch(err: &SLAError) -> bool {
+    matches!(err, SLAError::VersionMismatch)
+}
+
+pub fn is_contract_paused(err: &SLAError) -> bool {
+    matches!(err, SLAError::ContractPaused)
+}
+
+pub fn is_no_pending_transfer(err: &SLAError) -> bool {
+    matches!(err, SLAError::NoPendingTransfer)
+}
+
+pub fn is_invalid_threshold(err: &SLAError) -> bool {
+    matches!(err, SLAError::InvalidThreshold)
+}
+
+pub fn is_invalid_penalty(err: &SLAError) -> bool {
+    matches!(err, SLAError::InvalidPenalty)
+}
+
+pub fn is_invalid_reward(err: &SLAError) -> bool {
+    matches!(err, SLAError::InvalidReward)
+}
+
+pub fn is_invalid_severity(err: &SLAError) -> bool {
+    matches!(err, SLAError::InvalidSeverity)
+}
+
+pub fn is_retention_limit_out_of_range(err: &SLAError) -> bool {
+    matches!(err, SLAError::RetentionLimitOutOfRange)
+}
+
+pub fn is_duplicate_outage_input(err: &SLAError) -> bool {
+    matches!(err, SLAError::DuplicateOutageInput)
+}
+
+pub fn is_invalid_penalty_amount(err: &SLAError) -> bool {
+    matches!(err, SLAError::InvalidPenaltyAmount)
+}
+
+pub fn is_invalid_reward_amount(err: &SLAError) -> bool {
+    matches!(err, SLAError::InvalidRewardAmount)
+}
+
+pub fn is_config_frozen(err: &SLAError) -> bool {
+    matches!(err, SLAError::ConfigFrozen)
+}
+
+pub fn is_invalid_input(err: &SLAError) -> bool {
+    matches!(err, SLAError::InvalidInput)
+}

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -24,6 +24,7 @@ pub mod event_correlation;
 mod event_schema;
 pub mod history_snapshot;
 pub mod version_negotiation;
+pub mod error_responses;
 
 use crate::config_bundle::ConfigBundle;
 

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -5027,7 +5027,7 @@ fn test_error_already_initialized_is_terminal() {
     // Calling initialize twice always fails – no state change can make it succeed.
     let (_env, client, actors) = setup();
     let result = client.try_initialize(&actors.admin, &actors.operator);
-    assert_eq!(result.unwrap_err().unwrap(), SLAError::AlreadyInitialized);
+    assert!(error_responses::is_already_initialized(&result.unwrap_err().unwrap()));
 }
 
 #[test]
@@ -5041,14 +5041,14 @@ fn test_error_unauthorized_is_terminal_for_stranger() {
         &100,
         &750,
     );
-    assert_eq!(result.unwrap_err().unwrap(), SLAError::Unauthorized);
+    assert!(error_responses::is_unauthorized(&result.unwrap_err().unwrap()));
 }
 
 #[test]
 fn test_error_unauthorized_operator_calling_admin_fn_is_terminal() {
     let (_env, client, actors) = setup();
     let result = client.try_pause(&actors.operator, &soroban_sdk::String::from_str(&_env, "x"));
-    assert_eq!(result.unwrap_err().unwrap(), SLAError::Unauthorized);
+    assert!(error_responses::is_unauthorized(&result.unwrap_err().unwrap()));
 }
 
 #[test]
@@ -5056,7 +5056,7 @@ fn test_error_invalid_threshold_is_terminal() {
     let (_env, client, actors) = setup();
     // threshold=0 is always invalid for any severity
     let result = client.try_set_config(&actors.admin, &symbol_short!("low"), &0, &10, &600);
-    assert_eq!(result.unwrap_err().unwrap(), SLAError::InvalidThreshold);
+    assert!(error_responses::is_invalid_threshold(&result.unwrap_err().unwrap()));
 }
 
 #[test]
@@ -5064,7 +5064,7 @@ fn test_error_invalid_penalty_is_terminal() {
     let (_env, client, actors) = setup();
     // penalty=0 is always invalid
     let result = client.try_set_config(&actors.admin, &symbol_short!("low"), &120, &0, &600);
-    assert_eq!(result.unwrap_err().unwrap(), SLAError::InvalidPenalty);
+    assert!(error_responses::is_invalid_penalty(&result.unwrap_err().unwrap()));
 }
 
 #[test]
@@ -5072,14 +5072,14 @@ fn test_error_invalid_reward_is_terminal() {
     let (_env, client, actors) = setup();
     // reward=0 is always invalid
     let result = client.try_set_config(&actors.admin, &symbol_short!("low"), &120, &10, &0);
-    assert_eq!(result.unwrap_err().unwrap(), SLAError::InvalidReward);
+    assert!(error_responses::is_invalid_reward(&result.unwrap_err().unwrap()));
 }
 
 #[test]
 fn test_error_invalid_severity_is_terminal() {
     let (_env, client, actors) = setup();
     let result = client.try_set_config(&actors.admin, &symbol_short!("bogus"), &30, &50, &500);
-    assert_eq!(result.unwrap_err().unwrap(), SLAError::InvalidSeverity);
+    assert!(error_responses::is_invalid_severity(&result.unwrap_err().unwrap()));
 }
 
 #[test]
@@ -5087,7 +5087,7 @@ fn test_error_no_pending_transfer_is_terminal_without_proposal() {
     let (_env, client, actors) = setup();
     // No proposal exists – cancel must fail
     let result = client.try_cancel_admin_proposal(&actors.admin);
-    assert_eq!(result.unwrap_err().unwrap(), SLAError::NoPendingTransfer);
+    assert!(error_responses::is_no_pending_transfer(&result.unwrap_err().unwrap()));
 }
 
 #[test]
@@ -5104,10 +5104,7 @@ fn test_error_contract_paused_is_retryable_after_unpause() {
         &symbol_short!("high"),
         &10,
     );
-    assert_eq!(
-        paused_result.unwrap_err().unwrap(),
-        SLAError::ContractPaused
-    );
+    assert!(error_responses::is_contract_paused(&paused_result.unwrap_err().unwrap()));
 
     client.unpause(&actors.admin);
     let ok = client.calculate_sla(
@@ -5137,17 +5134,14 @@ fn test_error_config_not_found_is_retryable_after_set_config() {
     // We can't easily inject an unknown severity without bypassing validation,
     // so we verify ConfigNotFound is the error returned by get_config directly.
     let result = client.try_get_config(&symbol_short!("none"));
-    assert_eq!(result.unwrap_err().unwrap(), SLAError::ConfigNotFound);
+    assert!(error_responses::is_config_not_found(&result.unwrap_err().unwrap()));
 }
 
 #[test]
 fn test_error_retention_limit_out_of_range_is_terminal_for_zero() {
     let (_env, client, actors) = setup();
     let result = client.try_set_retention_limit(&actors.admin, &0);
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        SLAError::RetentionLimitOutOfRange
-    );
+    assert!(error_responses::is_retention_limit_out_of_range(&result.unwrap_err().unwrap()));
 }
 
 // ============================================================


### PR DESCRIPTION
closes #108

Title: feat: add typed error_responses helpers for SLAError and update tests
 Description
This PR introduces a new error_responses module that provides explicit, typed boolean helper functions for each SLAError variant (e.g., is_unauthorized(), is_not_initialized()).

Previously, callers (including backend tests and CLI wrappers) had to rely on knowing error codes by number or attempting direct enum matches, which was brittle and cumbersome when handling off-chain types. These new helper methods abstract that away and provide an ergonomic interface for validating contract execution failures.

Changes Made
src/error_responses.rs: Created the new module containing is_* helper functions for all variants of SLAError (e.g., is_already_initialized, is_invalid_threshold, etc.).
src/lib.rs: Exported the new error_responses module.
src/tests.rs: Refactored the test suite to use the newly introduced helpers in assertions, replacing direct unwrap comparisons (e.g., assert_eq!(result.unwrap_err().unwrap(), SLAError::AlreadyInitialized)) with cleaner abstractions (e.g., assert!(error_responses::is_already_initialized(&result.unwrap_err().unwrap()))).
 Testing
Local tests run and passing successfully. Error assertions function exactly as they did before, but now utilize the typed abstractions.