### PR TITLE
Add get_full_audit_state combined bootstrap read (#107)

### DIFF
--- a/apexchainx_calculator/src/audit_state.rs
+++ b/apexchainx_calculator/src/audit_state.rs
@@ -1,0 +1,72 @@
+use soroban_sdk::{contracttype, Address};
+
+use crate::{PauseInfo, SLAConfigSnapshot, SLAResultSchema, SLAStats};
+
+/// Combined audit-state envelope for one-shot backend bootstrap reads (#107).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuditState {
+    pub admin: Address,
+    pub operator: Address,
+    pub pending_admin: Option<Address>,
+    pub pending_operator: Option<Address>,
+    pub paused: bool,
+    pub pause_info: Option<PauseInfo>,
+    pub config_snapshot: SLAConfigSnapshot,
+    pub stats: SLAStats,
+    pub history_len: u32,
+    pub result_schema: SLAResultSchema,
+}
+
+#[cfg(test)]
+mod tests {
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+    use crate::{SLACalculatorContract, SLACalculatorContractClient};
+
+    fn setup() -> (Env, SLACalculatorContractClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, SLACalculatorContract);
+        let client = SLACalculatorContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let operator = Address::generate(&env);
+        client.initialize(&admin, &operator);
+        (env, client, admin, operator)
+    }
+
+    #[test]
+    fn test_audit_state_available_after_init() {
+        let (_env, client, admin, operator) = setup();
+        let state = client.get_full_audit_state();
+        assert_eq!(state.admin, admin);
+        assert_eq!(state.operator, operator);
+        assert!(!state.paused);
+        assert!(state.pause_info.is_none());
+        assert_eq!(state.history_len, 0);
+    }
+
+    #[test]
+    fn test_audit_state_matches_individual_getters() {
+        let (_env, client, _admin, _operator) = setup();
+        let state = client.get_full_audit_state();
+        assert_eq!(state.admin, client.get_admin());
+        assert_eq!(state.operator, client.get_operator());
+        assert_eq!(state.paused, client.is_paused());
+        assert_eq!(state.pause_info, client.get_pause_info());
+        assert_eq!(state.config_snapshot, client.get_config_snapshot());
+        assert_eq!(state.stats, client.get_stats());
+        assert_eq!(state.result_schema, client.get_result_schema());
+    }
+
+    #[test]
+    fn test_audit_state_reflects_stats_and_history_len() {
+        let (_env, client, _admin, operator) = setup();
+        client.calculate_sla(&operator, &symbol_short!("OUT1"), &symbol_short!("high"), &10);
+        client.calculate_sla(&operator, &symbol_short!("OUT2"), &symbol_short!("high"), &60);
+
+        let state = client.get_full_audit_state();
+        assert_eq!(state.history_len, 2);
+        assert_eq!(state.stats.total_calculations, 2);
+    }
+}

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -15,6 +15,7 @@ mod tests;
 #[cfg(test)]
 mod fuzz_tests;
 
+pub mod audit_state;
 pub mod config_bundle;
 pub mod config_freeze;
 pub mod config_metadata;
@@ -25,6 +26,7 @@ mod event_schema;
 pub mod history_snapshot;
 pub mod version_negotiation;
 
+use crate::audit_state::AuditState;
 use crate::config_bundle::ConfigBundle;
 
 // -----------------------------------------------------------------------
@@ -1149,6 +1151,40 @@ impl SLACalculatorContract {
         let snapshot = Self::get_config_snapshot(env.clone())?;
         let schema = Self::get_result_schema(env)?;
         Ok(Some(ConfigBundle { snapshot, schema }))
+    }
+
+    pub fn get_full_audit_state(env: Env) -> Result<AuditState, SLAError> {
+        Self::check_version(&env)?;
+
+        let admin = Self::get_admin(env.clone())?;
+        let operator = Self::get_operator(env.clone())?;
+        let pending_admin = Self::get_pending_admin(env.clone())?;
+        let pending_operator = Self::get_pending_operator(env.clone())?;
+        let paused = Self::is_paused(env.clone())?;
+        let pause_info = Self::get_pause_info(env.clone())?;
+        let config_snapshot = Self::get_config_snapshot(env.clone())?;
+        let stats = Self::get_stats(env.clone())?;
+        let result_schema = Self::get_result_schema(env.clone())?;
+
+        let history: Vec<SLAResult> = env
+            .storage()
+            .instance()
+            .get(&HISTORY_KEY)
+            .unwrap_or_else(|| Vec::new(&env));
+        let history_len = history.len();
+
+        Ok(AuditState {
+            admin,
+            operator,
+            pending_admin,
+            pending_operator,
+            paused,
+            pause_info,
+            config_snapshot,
+            stats,
+            history_len,
+            result_schema,
+        })
     }
 
     /// #60 – Returns static contract capabilities for backend introspection.


### PR DESCRIPTION
## Summary
Closes #107

Backends currently make ~10 separate calls to bootstrap their view of contract
state: `get_admin`, `get_operator`, `is_paused`, `get_pause_info`,
`get_pending_admin`, `get_pending_operator`, `get_config_snapshot`, `get_stats`,
a history read, and `get_result_schema`.

This PR adds a single new method, `get_full_audit_state()`, that returns a new
`AuditState` struct combining all of the above into one call.

## Design note: history is a count, not a page
The issue requires the composite output to stay small (< 1 KB). A full
`get_history_page(0, 50)` page of `SLAResult` entries cannot fit that budget
on its own — each entry carries two `i128` fields and five `Symbol` fields
(~70+ bytes per entry), so 50 entries alone would run to several KB.

`AuditState` therefore includes `history_len: u32` (a total count) instead of
embedding entries, following the same summarize-don't-embed pattern already
used by `history_snapshot::NormalizedSnapshot` elsewhere in this contract.
Everything else in the envelope is fixed-size or small (bounded by at most
four severities, plus an optional 256-byte pause reason), so it's included
in full. Callers that need bulk history should keep using
`get_history_page` / `get_history_by_outage`.

## Changes
- New file: `apexchainx_calculator/src/audit_state.rs` — `AuditState` struct + unit tests
- `lib.rs`: registers the module, imports `AuditState`, adds `get_full_audit_state()`

## Testing
- [ ] `cargo test --lib` passes locally