### PR TITLE
test: add CPU budget coverage for pause/unpause/freeze/governance mutating fns (#91)

### DIFF
--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -880,6 +880,385 @@ fn test_set_config_budget_is_reasonable() {
         "set_config too expensive: {} instructions",
         after - before
     );
+   
+}
+
+#[test]
+fn test_pause_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    let reason = soroban_sdk::String::from_str(&env, "budget test");
+    let before = env.budget().cpu_instruction_cost();
+    client.pause(&admin, &reason);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 100_000,
+        "pause too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_unpause_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+    client.pause(&admin, &soroban_sdk::String::from_str(&env, "setup"));
+
+    let before = env.budget().cpu_instruction_cost();
+    client.unpause(&admin);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 100_000,
+        "unpause too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_freeze_config_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.freeze_config(&admin);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 100_000,
+        "freeze_config too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_unfreeze_config_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+    client.freeze_config(&admin);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.unfreeze_config(&admin);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 100_000,
+        "unfreeze_config too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_propose_admin_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+    let new_admin = soroban_sdk::Address::generate(&env);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.propose_admin(&admin, &new_admin);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 120_000,
+        "propose_admin too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_accept_admin_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+    let new_admin = soroban_sdk::Address::generate(&env);
+    client.propose_admin(&admin, &new_admin);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.accept_admin(&new_admin);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 120_000,
+        "accept_admin too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_cancel_admin_proposal_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+    let new_admin = soroban_sdk::Address::generate(&env);
+    client.propose_admin(&admin, &new_admin);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.cancel_admin_proposal(&admin);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 100_000,
+        "cancel_admin_proposal too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_propose_operator_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+    let new_op = soroban_sdk::Address::generate(&env);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.propose_operator(&admin, &new_op);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 120_000,
+        "propose_operator too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_accept_operator_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+    let new_op = soroban_sdk::Address::generate(&env);
+    client.propose_operator(&admin, &new_op);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.accept_operator(&new_op);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 120_000,
+        "accept_operator too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_cancel_operator_proposal_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+    let new_op = soroban_sdk::Address::generate(&env);
+    client.propose_operator(&admin, &new_op);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.cancel_operator_proposal(&admin);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 100_000,
+        "cancel_operator_proposal too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_renounce_admin_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.renounce_admin(&admin);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 100_000,
+        "renounce_admin too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_set_operator_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+    let new_op = soroban_sdk::Address::generate(&env);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.set_operator(&admin, &new_op);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 100_000,
+        "set_operator too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_set_retention_limit_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.set_retention_limit(&admin, &50);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 100_000,
+        "set_retention_limit too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_prune_history_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    for i in 0..20u32 {
+        let oid = Symbol::new(&env, &alloc::format!("PB_{}", i));
+        client.calculate_sla(&op, &oid, &symbol_short!("low"), &10);
+    }
+
+    let before = env.budget().cpu_instruction_cost();
+    client.prune_history(&admin, &5);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 250_000,
+        "prune_history too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_prune_history_by_age_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+    env.ledger().set_timestamp(1000);
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    for i in 0..20u32 {
+        let oid = Symbol::new(&env, &alloc::format!("PA_{}", i));
+        client.calculate_sla(&op, &oid, &symbol_short!("low"), &10);
+    }
+    env.ledger().set_timestamp(2000);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.prune_history_by_age(&admin, &500);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 250_000,
+        "prune_history_by_age too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_migrate_budget_is_reasonable() {
+    let env = Env::default();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.migrate(&admin);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 100_000,
+        "migrate too expensive: {} instructions",
+        after - before
+    );
 }
 
 // ============================================================

--- a/docs/sc-w5-storage-and-cost-baselines.md
+++ b/docs/sc-w5-storage-and-cost-baselines.md
@@ -10,6 +10,7 @@
 - [Pruning-by-Age Chronology](#pruning-by-age-chronology)
 - [Storage Footprint Telemetry](#storage-footprint-telemetry)
 - [Critical Path Cost Baseline](#critical-path-cost-baseline)
+- [Mutating Function CPU Budgets](#mutating-function-cpu-budgets)
 - [Regression Detection](#regression-detection)
 
 ---
@@ -116,9 +117,57 @@ fn test_no_storage_key_collisions() {
 
 ---
 
-## Regression Detection
+## Mutating Function CPU Budgets
 
-### Automated Checks
+Every state-mutating entrypoint has a CPU instruction budget test (see
+`apexchainx_calculator/src/tests.rs`, `#91`). Each test measures a single call
+in isolation using `env.budget().reset_unlimited()` before invocation and
+`env.budget().cpu_instruction_cost()` snapshots immediately before/after the
+call, then asserts the delta stays under the ceiling below.
+
+| Function | CPU Instruction Ceiling | Notes |
+|----------|------------------------|-------|
+| `calculate_sla` | 200,000 | Existing baseline |
+| `set_config` | 150,000 | Existing baseline |
+| `pause` | 100,000 | Single flag + metadata write |
+| `unpause` | 100,000 | Single flag + metadata clear |
+| `freeze_config` | 100,000 | Single flag write |
+| `unfreeze_config` | 100,000 | Single flag write |
+| `propose_admin` | 120,000 | Two-step governance write |
+| `accept_admin` | 120,000 | Two-step governance write |
+| `cancel_admin_proposal` | 100,000 | Clears pending state |
+| `propose_operator` | 120,000 | Two-step governance write |
+| `accept_operator` | 120,000 | Two-step governance write |
+| `cancel_operator_proposal` | 100,000 | Clears pending state |
+| `renounce_admin` | 100,000 | Irreversible single write |
+| `set_operator` | 100,000 | Single-step role write |
+| `set_retention_limit` | 100,000 | Single config write |
+| `prune_history` | 250,000 | Scales with history size pruned |
+| `prune_history_by_age` | 250,000 | Scales with history size pruned |
+| `migrate` | 100,000 | No-op path when already current |
+
+### Ceiling Rationale
+
+- **Simple state flips** (pause/unpause/freeze/unfreeze/renounce/set_operator/set_retention_limit)
+  touch one or two storage slots, so 100,000 instructions gives comfortable
+  headroom without masking a real regression.
+- **Two-step governance functions** (propose/accept/cancel for admin and
+  operator) do slightly more work validating caller identity against pending
+  state, so they get a modestly higher ceiling (120,000).
+- **History-pruning functions** iterate over stored records, so their ceiling
+  (250,000) is sized for the test's fixture volume (~20 entries) rather than
+  a fixed small state write. If typical production history sizes grow
+  significantly, this ceiling should be revisited.
+
+### Updating Ceilings
+
+If a CI run reports an assertion failure with the actual instruction count,
+update the corresponding row above and the matching `assert!` threshold in
+`tests.rs` together, so this table never drifts from the enforced values.
+
+---
+
+## Regression Detection
 
 | Check | Trigger | Action |
 |-------|---------|--------|


### PR DESCRIPTION
## Summary
Closes #91.

The existing budget test suite only asserted a CPU instruction budget for
`calculate_sla` and `set_config`. Every other mutating function had no
upper bound on CPU/memory growth, so a regression that made one of them
unexpectedly expensive would go unnoticed.

This PR extends CPU budget coverage to all remaining mutating functions:

- `pause` / `unpause`
- `freeze_config` / `unfreeze_config`
- `propose_admin` / `accept_admin` / `cancel_admin_proposal`
- `propose_operator` / `accept_operator` / `cancel_operator_proposal`
- `renounce_admin`
- `set_operator`
- `set_retention_limit`
- `prune_history` / `prune_history_by_age`
- `migrate`

## Approach
Each new test follows the existing pattern used by
`test_calculate_sla_budget_is_reasonable` /
`test_set_config_budget_is_reasonable`:

1. `env.budget().reset_unlimited()` so the call isn't capped mid-measurement
2. snapshot `cpu_instruction_cost()` immediately before the call under test
3. invoke the single mutating function
4. snapshot `cpu_instruction_cost()` again and assert the delta is under a
   fixed ceiling

Where a function needs prior state (e.g. `accept_admin` needs a pending
proposal from `propose_admin`), that setup happens *before* the `before`
snapshot so only the target call is measured.

## Docs
Chosen budgets are documented in `docs/sc-w5-storage-and-cost-baselines.md`.

## Testing
`cargo test` run locally / via CI — all new `*_budget_is_reasonable` tests
pass alongside the existing suite.