### PR TITLE
docs: update event convention section to reference authoritative even…

### DIFF
--- a/docs/CODEX_CONTEXT.md
+++ b/docs/CODEX_CONTEXT.md
@@ -316,30 +316,18 @@ Current symbol mappings:
 - rating good -> `good`
 - rating poor -> `poor`
 
-Compatibility rule:\n\n- additive read-only contract helpers are preferred over changing the shape of\n  `SLAResult`\n- **Versioning**: Breaking ABI/symbol changes → MAJOR bump (v2.0.0), update `schema_version` in `get_result_schema()`.\n- Backend: Pin contract ID/version, regenerate parity tests from snapshots post-release.\n\n**Backend Dependency Expectations**:\n- Match `calculate_sla_view()` exactly with local logic.\n- Consume `test_snapshots/tests/*.json` for golden vectors.\n- Monitor git tags `vX.Y.Z` for releases.\n\n## Event Convention
+Compatibility rule:\n\n- additive read-only contract helpers are preferred over changing the shape of\n  `SLAResult`\n- **Versioning**: Breaking ABI/symbol changes → MAJOR bump (v2.0.0), update `schema_version` in `get_result_schema()`.\n- Backend: Pin contract ID/version, regenerate parity tests from snapshots post-release.\n\n**Backend Dependency Expectations**:\n- Match `calculate_sla_view()` exactly with local logic.\n- Consume `test_snapshots/tests/*.json` for golden vectors.\n- Monitor git tags `vX.Y.Z` for releases.\n\n## Event Conventions
 
-Lifecycle events are versioned so backend consumers can reason about event shape
-without inferring it from position alone.
+For the canonical reference on Soroban event commit timing, event semantics, and
+full event catalog details, see [docs/AUDIT_TRAIL.md](AUDIT_TRAIL.md). This
+context document keeps only the repository-specific conventions and points
+readers to that authoritative explanation instead of restating the full catalog.
 
-Current event topic convention:
+The local event topic convention remains:
 
 - topic 0 -> event name
 - topic 1 -> event version
 - topic 2 -> event-specific context such as severity or caller
-
-Current event version:
-
-- `v1`
-
-Current SLA calculation event payload:
-
-- outage id
-- result status
-- payment type
-- rating
-- MTTR minutes
-- threshold minutes
-- amount
 
 ---
 


### PR DESCRIPTION
Closes #119 

## Description
This PR updates the documentation in [docs/CODEX_CONTEXT.md](docs/CODEX_CONTEXT.md) to point readers to the authoritative event-semantics reference instead of duplicating event catalog details in the context document. The change keeps the section concise while preserving the repository-specific topic-convention notes.

## Type of Change
- [x] Documentation update

## Related Issues
Relates to #42

## Changes Made
- Replaced the duplicated event-catalog narrative in [docs/CODEX_CONTEXT.md](docs/CODEX_CONTEXT.md) with a concise cross-reference to the audit-trail documentation.
- Kept the local event topic-convention bullets in place for repository-specific guidance.
- Clarified that the context document should not restate the full event semantics catalog.

## Testing
Describe the testing performed to validate these changes:
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Manual testing performed
- Reviewed the updated markdown section in [docs/CODEX_CONTEXT.md](docs/CODEX_CONTEXT.md) to confirm the new cross-reference and wording are present.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented complex logic
- [x] I have updated relevant documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] My changes do not introduce new warnings

