### PR TITLE
quote colon-ending run command in ci.yml (fixes YAML parse error)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Run property-based fuzz tests
         working-directory: apexchainx_calculator
-        run: cargo test --lib fuzz_tests::
+        run: "cargo test --lib fuzz_tests::"
 
 
   provenance-hashes:


### PR DESCRIPTION
## Description
Fixes a YAML syntax error in ci.yml that was blocking all CI checks from running on PRs.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made
- Wrapped the `run` command on line 127 in quotes, since it ends with `::` which YAML was misinterpreting as a mapping indicator instead of a literal string
- This was preventing the entire workflow file from being parsed, so none of the four CI jobs (client-checks, e2e-tests, fuzz-tests, provenance-hashes) could register on any open PR — confirmed on PR #137

## Testing
- [x] Manual testing performed (validated YAML syntax)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code