### PR TITLE
ci: invoke gen-roadmap.ts after release build (#105)

### DIFF
--- a/.github/workflows/release-hash.yml
+++ b/.github/workflows/release-hash.yml
@@ -63,6 +63,18 @@ jobs:
           sha256sum -c manifest.sha256
           rm apexchainx_calculator.wasm
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate ROADMAP.md
+        run: |
+          echo "📄 Generating docs/ROADMAP.md from tools/gen-roadmap.ts..."
+          npx --yes ts-node tools/gen-roadmap.ts
+          echo "✅ ROADMAP.md generated:"
+          cat docs/ROADMAP.md
+
       - name: Upload manifest as workflow artifact
         uses: actions/upload-artifact@v4
         with:
@@ -70,6 +82,7 @@ jobs:
           path: |
             manifest.sha256
             apexchainx_calculator/target/wasm32-unknown-unknown/release/apexchainx_calculator.wasm
+            docs/ROADMAP.md
           retention-days: 90
 
       - name: Attach manifest to GitHub Release
@@ -78,3 +91,4 @@ jobs:
           files: |
             manifest.sha256
             apexchainx_calculator/target/wasm32-unknown-unknown/release/apexchainx_calculator.wasm
+            docs/ROADMAP.md


### PR DESCRIPTION
## Summary

Closes #105.

`tools/gen-roadmap.ts` existed but was never called by CI. This change wires it into the release workflow so `docs/ROADMAP.md` is generated and shipped automatically on every `v*` tag push.

## Changes

- **`Set up Node.js`** step added (Node 20 LTS) after WASM manifest verification.
- **`Generate ROADMAP.md`** step runs `npx --yes ts-node tools/gen-roadmap.ts` — no `package.json` or pre-installed deps required; `--yes` auto-installs `ts-node` on demand.
- `docs/ROADMAP.md` added to the workflow artifact upload and to the GitHub Release file list.

## What was tested

- Workflow YAML syntax verified locally.
- Script uses CommonJS-compatible `__dirname` / `fs.writeFileSync`, compatible with `ts-node` default CJS mode (no `tsconfig.json` needed).

## Files changed

- `.github/workflows/release-hash.yml`