### PR TITLE
ci: wire normalize-snapshots.ts into e2e-tests job (#81)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,19 @@ jobs:
         working-directory: apexchainx_calculator
         run: cargo test --lib
 
+      # Issue #81: Normalize snapshot artifacts before upload so that volatile
+      # fields (timestamp, elapsed_ms, generated_at) are stripped and keys are
+      # sorted. This prevents noisy PR diffs caused by non-semantic changes.
+      - name: Normalize snapshot artifacts
+        run: npx --yes tsx tools/normalize-snapshots.ts
+
+      - name: Upload snapshot artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sla-test-snapshots
+          path: apexchainx_calculator/test_snapshots/tests/
+          retention-days: 30
+
   fuzz-tests:
     name: Fuzz Tests (proptest)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Closes #81

`tools/normalize-snapshots.ts` existed but was never invoked in CI, causing PR snapshot diffs to include volatile fields (`timestamp`, `elapsed_ms`, `generated_at`) that produce noise unrelated to real logic changes.

## Changes

**`.github/workflows/ci.yml`** — two steps added to the `e2e-tests` job, after `cargo test --lib`:

- **Normalize snapshot artifacts**: runs `npx --yes tsx tools/normalize-snapshots.ts` from the repo root. Strips volatile keys and sorts JSON keys so diffs are deterministic and semantic-only.
- **Upload snapshot artifacts**: uploads the normalized `apexchainx_calculator/test_snapshots/tests/` directory as the `sla-test-snapshots` artifact (30-day retention).

## Why `e2e-tests` and not `client-checks`

Snapshots are generated by `cargo test --lib`, which only runs in `e2e-tests`. Normalizing before they exist would be a no-op.

## Why `npx --yes tsx`

No `package.json` exists in the repo, so there is no pre-installed runtime. `tsx` is fetched on demand; `--yes` skips the interactive prompt. The script only uses Node built-ins (`fs`, `path`), so no additional dependencies are needed.

## Testing

- Normalize step exits cleanly when the snapshot directory does not yet exist (script handles this with an early-return guard).
- After `cargo test --lib` produces snapshots, the step strips volatile fields and logs `normalized:` or `unchanged:` per file.