### PR TITLE
ci: show format diff on cargo fmt failure in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,17 @@ jobs:
 
       - name: Format check
         working-directory: apexchainx_calculator
-        run: cargo fmt --check
+        run: |
+          cargo fmt -- --check --color=always 2>&1 | tee fmt_output.log
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+            echo ""
+            echo "=== Formatting diff ==="
+            cargo fmt -- --check 2>&1 || true
+            git diff -- '*.rs' || true
+            echo ""
+            echo "Run 'cargo fmt' locally to fix."
+            exit 1
+          fi
 
       - name: Clippy
         working-directory: apexchainx_calculator


### PR DESCRIPTION
## Summary

Before this change, `cargo fmt --check` fails silently with no output showing which files are unformatted.

### Changes

- Runs with `--color=always` for readable terminal output
- On failure, re-runs the check and shows `git diff` of Rust files
- Prints a helpful message to run `cargo fmt` locally

Closes #86