### PR TITLE
feat: add get_economic_exposure view for backend dashboarding (#96)

### DIFF
--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -438,6 +438,54 @@ pub struct SLAStats {
     pub total_penalties: i128, // sum of all penalty amounts (stored positive)
 }
 
+/// #96 – Per-severity economic exposure for a single SLA event.
+///
+/// `max_reward` is the top-tier reward (`reward_base * 200 / 100`) — the most
+/// a single perfectly-resolved event of this severity can pay out.
+///
+/// `penalty_per_minute` is the configured per-minute penalty rate — the
+/// marginal cost of each overtime minute for a single violated event.
+/// The total penalty for one event grows linearly: `overtime_minutes *
+/// penalty_per_minute`. There is no contract-level cap on overtime, so the
+/// dashboard must apply its own horizon when projecting worst-case exposure.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SeverityExposure {
+    /// Severity level (critical, high, medium, low).
+    pub severity: Symbol,
+    /// Maximum reward for a single top-tier event of this severity.
+    pub max_reward: i128,
+    /// Per-overtime-minute penalty rate for a single violated event.
+    pub penalty_per_minute: i128,
+}
+
+/// #96 – Aggregate economic exposure view for backend dashboarding.
+///
+/// Summarises the maximum potential reward and the per-minute penalty rate
+/// across all configured severities. This is a pure view — it reads only
+/// the current severity configs and performs no state mutation.
+///
+/// `total_max_reward` is the sum of `max_reward` across all severities —
+/// the total that would be paid out if one top-tier event occurred per
+/// severity simultaneously.
+///
+/// `total_penalty_per_minute` is the sum of `penalty_per_minute` across all
+/// severities — the aggregate cost rate if every severity had one ongoing
+/// violation simultaneously.
+///
+/// `breakdown` contains one entry per canonical severity in canonical order
+/// (critical → high → medium → low).
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EconomicExposure {
+    /// Sum of `max_reward` across all severities.
+    pub total_max_reward: i128,
+    /// Sum of `penalty_per_minute` across all severities.
+    pub total_penalty_per_minute: i128,
+    /// Per-severity breakdown in canonical order.
+    pub breakdown: Vec<SeverityExposure>,
+}
+
 /// #101 – Per-severity weekly violation-rate telemetry snapshot.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1416,6 +1464,57 @@ impl SLACalculatorContract {
             .instance()
             .get(&STATS_KEY)
             .ok_or(SLAError::NotInitialized)
+    }
+
+    // -------------------------------------------------------------------
+    // #96 – Economic exposure view for backend dashboarding
+    // -------------------------------------------------------------------
+
+    /// Returns the maximum potential reward and per-minute penalty rate for
+    /// every configured severity, plus aggregate totals.
+    ///
+    /// This is a read-only view — it does **not** require auth, does not
+    /// mutate state, and does not emit events. It can be called while the
+    /// contract is paused because it only reads configuration data.
+    ///
+    /// The top-tier reward multiplier (200 %) is applied to `reward_base` to
+    /// yield `max_reward` — matching the `compute_result` path for
+    /// `performance_ratio < 50`.
+    pub fn get_economic_exposure(env: Env) -> Result<EconomicExposure, SLAError> {
+        Self::check_version(&env)?;
+
+        let mut breakdown = Vec::new(&env);
+        let mut total_max_reward: i128 = 0;
+        let mut total_penalty_per_minute: i128 = 0;
+
+        for severity in Self::canonical_severities(&env) {
+            let cfg = Self::load_config(&env, &severity)?;
+
+            // Top-tier reward: performance_ratio < 50 → multiplier = 200 %
+            // Mirrors compute_result exactly: reward_base * 200 / 100
+            let max_reward = cfg
+                .reward_base
+                .checked_mul(200)
+                .map(|v| v.div_euclid(100))
+                .unwrap_or(i128::MAX);
+
+            let penalty_rate = cfg.penalty_per_minute;
+
+            total_max_reward = total_max_reward.saturating_add(max_reward);
+            total_penalty_per_minute = total_penalty_per_minute.saturating_add(penalty_rate);
+
+            breakdown.push_back(SeverityExposure {
+                severity,
+                max_reward,
+                penalty_per_minute: penalty_rate,
+            });
+        }
+
+        Ok(EconomicExposure {
+            total_max_reward,
+            total_penalty_per_minute,
+            breakdown,
+        })
     }
 
     /// Per-severity counters are packed as four `u32` lanes inside one `u128`,

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -6933,3 +6933,143 @@ fn test_calculate_sla_rejects_unregistered_custom_severity() {
         &45,
     );
 }
+
+// ============================================================
+// Issue #96 – get_economic_exposure
+// ============================================================
+
+/// (a) After initialization the function returns one entry per canonical
+/// severity in canonical order.
+#[test]
+fn test_economic_exposure_returns_all_severities() {
+    let (_env, client, _actors) = setup();
+    let exposure = client.get_economic_exposure();
+    assert_eq!(exposure.breakdown.len(), 4);
+    assert_eq!(exposure.breakdown.get(0).unwrap().severity, symbol_short!("critical"));
+    assert_eq!(exposure.breakdown.get(1).unwrap().severity, symbol_short!("high"));
+    assert_eq!(exposure.breakdown.get(2).unwrap().severity, symbol_short!("medium"));
+    assert_eq!(exposure.breakdown.get(3).unwrap().severity, symbol_short!("low"));
+}
+
+/// (b) `max_reward` for each severity equals `reward_base * 200 / 100`,
+/// matching the top-tier multiplier in `compute_result`.
+#[test]
+fn test_economic_exposure_max_reward_matches_top_tier() {
+    let (_env, client, _actors) = setup();
+    let exposure = client.get_economic_exposure();
+
+    // Default configs: critical/high/medium → reward_base 750, low → 600
+    // Top-tier (200 %): 750 * 200 / 100 = 1500; 600 * 200 / 100 = 1200
+    let critical = exposure.breakdown.get(0).unwrap();
+    let high     = exposure.breakdown.get(1).unwrap();
+    let medium   = exposure.breakdown.get(2).unwrap();
+    let low      = exposure.breakdown.get(3).unwrap();
+
+    assert_eq!(critical.max_reward, 1500);
+    assert_eq!(high.max_reward,     1500);
+    assert_eq!(medium.max_reward,   1500);
+    assert_eq!(low.max_reward,      1200);
+}
+
+/// (c) `penalty_per_minute` for each severity matches the configured rate.
+#[test]
+fn test_economic_exposure_penalty_rate_matches_config() {
+    let (_env, client, _actors) = setup();
+    let exposure = client.get_economic_exposure();
+
+    // Default penalty_per_minute: critical=100, high=50, medium=25, low=10
+    let critical = exposure.breakdown.get(0).unwrap();
+    let high     = exposure.breakdown.get(1).unwrap();
+    let medium   = exposure.breakdown.get(2).unwrap();
+    let low      = exposure.breakdown.get(3).unwrap();
+
+    assert_eq!(critical.penalty_per_minute, 100);
+    assert_eq!(high.penalty_per_minute,      50);
+    assert_eq!(medium.penalty_per_minute,    25);
+    assert_eq!(low.penalty_per_minute,       10);
+}
+
+/// (d) Aggregate `total_max_reward` equals the sum of per-severity max rewards.
+#[test]
+fn test_economic_exposure_total_max_reward_is_sum_of_breakdown() {
+    let (_env, client, _actors) = setup();
+    let exposure = client.get_economic_exposure();
+
+    // Default: 1500 + 1500 + 1500 + 1200 = 5700
+    let expected_total: i128 = exposure
+        .breakdown
+        .iter()
+        .map(|e| e.max_reward)
+        .sum();
+    assert_eq!(exposure.total_max_reward, expected_total);
+    assert_eq!(exposure.total_max_reward, 5700);
+}
+
+/// (e) Aggregate `total_penalty_per_minute` equals the sum of per-severity
+/// penalty rates.
+#[test]
+fn test_economic_exposure_total_penalty_per_minute_is_sum_of_breakdown() {
+    let (_env, client, _actors) = setup();
+    let exposure = client.get_economic_exposure();
+
+    // Default: 100 + 50 + 25 + 10 = 185
+    let expected_total: i128 = exposure
+        .breakdown
+        .iter()
+        .map(|e| e.penalty_per_minute)
+        .sum();
+    assert_eq!(exposure.total_penalty_per_minute, expected_total);
+    assert_eq!(exposure.total_penalty_per_minute, 185);
+}
+
+/// (f) After `set_config` the exposure values reflect the updated config.
+#[test]
+fn test_economic_exposure_reflects_config_change() {
+    let (_env, client, actors) = setup();
+
+    // Override critical: reward_base=1000 → max_reward = 2000; penalty_per_minute=200
+    client.set_config(&actors.admin, &symbol_short!("critical"), &10, &200, &1000);
+
+    let exposure = client.get_economic_exposure();
+    let critical = exposure.breakdown.get(0).unwrap();
+
+    assert_eq!(critical.max_reward,        2000);
+    assert_eq!(critical.penalty_per_minute, 200);
+
+    // Totals must also update: was 5700 reward, now (2000 + 1500 + 1500 + 1200) = 6200
+    assert_eq!(exposure.total_max_reward, 6200);
+    // Was 185 penalty rate, now (200 + 50 + 25 + 10) = 285
+    assert_eq!(exposure.total_penalty_per_minute, 285);
+}
+
+/// (g) The view is callable while the contract is paused — it must not
+/// return ContractPaused.
+#[test]
+fn test_economic_exposure_callable_while_paused() {
+    let (env, client, actors) = setup();
+    client.pause(&actors.admin, &soroban_sdk::String::from_str(&env, "maintenance"));
+    // Should not panic
+    let exposure = client.get_economic_exposure();
+    assert_eq!(exposure.breakdown.len(), 4);
+}
+
+/// (h) The view is independent of calculation history — pruning history
+/// does not alter the exposure values.
+#[test]
+fn test_economic_exposure_independent_of_history() {
+    let (env, client, actors) = setup();
+
+    // Run a couple of calculations to populate history
+    env.mock_all_auths();
+    client.calculate_sla(&actors.operator, &symbol_short!("out001"), &symbol_short!("critical"), &5);
+    client.calculate_sla(&actors.operator, &symbol_short!("out002"), &symbol_short!("high"), &40);
+
+    let exposure_before = client.get_economic_exposure();
+
+    // Prune all but the most recent entry
+    client.prune_history(&actors.admin, &1);
+
+    let exposure_after = client.get_economic_exposure();
+
+    assert_eq!(exposure_before, exposure_after);
+}


### PR DESCRIPTION
## Summary

Closes #96.

Adds a new read-only view `get_economic_exposure(env) -> Result<EconomicExposure, SLAError>` so the backend dashboard can query the maximum potential financial exposure across all configured severities without relying on prunable history.

## Problem

`get_stats` reflects cumulative history totals. After pruning, it only covers the retained window. A dashboard needs to know: *"if one event per severity fires simultaneously at worst-case, what is the total max payout / penalty rate?"* — a config-derived answer that is unaffected by history pruning.

## Changes

### `lib.rs`

- **`SeverityExposure`** struct (new):
  - `severity: Symbol`
  - `max_reward: i128` — top-tier reward (`reward_base * 200 / 100`), mirrors the `performance_ratio < 50` branch in `compute_result` exactly
  - `penalty_per_minute: i128` — marginal cost per overtime minute for a violated event

- **`EconomicExposure`** struct (new):
  - `total_max_reward: i128` — sum of `max_reward` across all severities
  - `total_penalty_per_minute: i128` — sum of `penalty_per_minute` across all severities
  - `breakdown: Vec<SeverityExposure>` — one entry per canonical severity (critical → high → medium → low)

- **`get_economic_exposure(env)`** (new public fn):
  - Pure view — no auth, no state mutation, no events
  - Callable while paused (reads only config, not pause-gated state)
  - Iterates `canonical_severities`, calls `load_config` per severity, accumulates totals

### `tests.rs`

8 new tests:

| Test | Assertion |
|------|-----------|
| `returns_all_severities` | 4 entries in canonical order |
| `max_reward_matches_top_tier` | Default values → 1500/1500/1500/1200 |
| `penalty_rate_matches_config` | Default rates → 100/50/25/10 |
| `total_max_reward_is_sum_of_breakdown` | Aggregate = 5700 |
| `total_penalty_per_minute_is_sum_of_breakdown` | Aggregate = 185 |
| `reflects_config_change` | Totals update after `set_config` |
| `callable_while_paused` | No panic when contract is paused |
| `independent_of_history` | Result unchanged after `prune_history` |

## Testing

```
cargo test economic_exposure
# 8 passed; 0 failed

cargo test
# 480 passed; 0 failed
```