### PR TITLE
feat(#94): add cron-style history-pruning policy helper

### DIFF
--- a/apexchainx_calculator/src/event_schema.rs
+++ b/apexchainx_calculator/src/event_schema.rs
@@ -57,6 +57,11 @@
 //! - topic[2]: caller Address
 //! - payload:  (removed_count: u32, kept_count: u32)
 //!
+//! ## pruned_p (`pruned_p`)
+//! Emitted after an apply_prune_policy call removes entries. (#94)
+//! - topic[2]: caller Address
+//! - payload:  (removed_count: u32, kept_count: u32)
+//!
 //! ## adm_prop (`adm_prop`)
 //! Emitted when a new admin is proposed.
 //! - topic[2]: caller Address
@@ -181,6 +186,7 @@ pub const EVENT_UNPAUSED: Symbol = symbol_short!("unpause");
 pub const EVENT_OP_SET: Symbol = symbol_short!("op_set");
 pub const EVENT_PRUNED: Symbol = symbol_short!("pruned");
 pub const EVENT_PRUNED_AGE: Symbol = symbol_short!("pruned_a");
+pub const EVENT_PRUNED_POLICY: Symbol = symbol_short!("pruned_p");
 pub const EVENT_ADMIN_PROP: Symbol = symbol_short!("adm_prop");
 pub const EVENT_ADMIN_ACC: Symbol = symbol_short!("adm_acc");
 pub const EVENT_ADMIN_CAN: Symbol = symbol_short!("adm_can");
@@ -220,6 +226,7 @@ mod tests {
             EVENT_OP_SET,
             EVENT_PRUNED,
             EVENT_PRUNED_AGE,
+            EVENT_PRUNED_POLICY,
             EVENT_ADMIN_PROP,
             EVENT_ADMIN_ACC,
             EVENT_ADMIN_CAN,

--- a/apexchainx_calculator/src/history.rs
+++ b/apexchainx_calculator/src/history.rs
@@ -1,8 +1,8 @@
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
 use crate::{
-    SLAError, SLAResult,
-    HISTORY_KEY, RETENTION_LIMIT_KEY, MAX_HISTORY_SIZE, EVENT_VERSION, EVENT_PRUNED, EVENT_PRUNED_AGE,
+    SLAError, SLAResult, PrunePolicy,
+    HISTORY_KEY, RETENTION_LIMIT_KEY, MAX_HISTORY_SIZE, MAX_CRON_EXPR_LEN, PRUNE_POLICY_KEY, EVENT_VERSION, EVENT_PRUNED, EVENT_PRUNED_AGE, EVENT_PRUNED_POLICY,
 };
 
 pub fn get_history(env: &Env) -> Result<Vec<SLAResult>, SLAError> {
@@ -156,4 +156,74 @@ pub fn get_retention_limit(env: &Env) -> Result<u32, SLAError> {
         .instance()
         .get(&RETENTION_LIMIT_KEY)
         .unwrap_or(MAX_HISTORY_SIZE))
+}
+
+pub fn set_prune_policy(env: &Env, caller: &Address, policy: &PrunePolicy) -> Result<(), SLAError> {
+    crate::SLACalculatorContract::check_version(env)?;
+    crate::SLACalculatorContract::require_admin(env, caller)?;
+
+    if policy.cron_expr.len() > MAX_CRON_EXPR_LEN as u32 {
+        return Err(SLAError::InvalidInput);
+    }
+
+    env.storage().instance().set(&PRUNE_POLICY_KEY, policy);
+    Ok(())
+}
+
+pub fn get_prune_policy(env: &Env) -> Result<Option<PrunePolicy>, SLAError> {
+    crate::SLACalculatorContract::check_version(env)?;
+    Ok(env.storage().instance().get(&PRUNE_POLICY_KEY))
+}
+
+pub fn apply_prune_policy(env: &Env, caller: &Address) -> Result<(), SLAError> {
+    crate::SLACalculatorContract::check_version(env)?;
+    crate::SLACalculatorContract::require_admin(env, caller)?;
+
+    let policy: PrunePolicy = env
+        .storage()
+        .instance()
+        .get(&PRUNE_POLICY_KEY)
+        .ok_or(SLAError::NoPrunePolicy)?;
+
+    let mut history: Vec<SLAResult> = env
+        .storage()
+        .instance()
+        .get(&HISTORY_KEY)
+        .unwrap_or_else(|| Vec::new(env));
+
+    let mut total_removed: u32 = 0;
+
+    if policy.keep_latest > 0 && history.len() > policy.keep_latest {
+        let remove_count = history.len() - policy.keep_latest;
+        total_removed += remove_count;
+        let mut new_history = Vec::new(env);
+        for i in remove_count..history.len() {
+            new_history.push_back(history.get(i).unwrap());
+        }
+        history = new_history;
+    }
+
+    if policy.max_age_seconds > 0 {
+        let now = env.ledger().timestamp();
+        let cutoff = now.saturating_sub(policy.max_age_seconds);
+        let mut new_history = Vec::new(env);
+        for i in 0..history.len() {
+            let entry = history.get(i).unwrap();
+            if entry.recorded_at >= cutoff {
+                new_history.push_back(entry);
+            } else {
+                total_removed += 1;
+            }
+        }
+        history = new_history;
+    }
+
+    if total_removed > 0 {
+        let kept = history.len();
+        env.storage().instance().set(&HISTORY_KEY, &history);
+        env.events()
+            .publish((EVENT_PRUNED_POLICY, EVENT_VERSION, caller.clone()), (total_removed, kept));
+    }
+
+    Ok(())
 }

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -73,6 +73,9 @@ pub(crate) const PAUSE_INFO_KEY: Symbol = symbol_short!("PAUSEINF");
 /// Maximum length (in bytes) for the pause reason string. (#68)
 pub(crate) const MAX_REASON_LEN: usize = 256;
 
+/// Maximum length (in bytes) for the cron expression in PrunePolicy. (#94)
+pub(crate) const MAX_CRON_EXPR_LEN: usize = 128;
+
 /// Cumulative SLA statistics (SLAStats struct). (#29)
 pub(crate) const STATS_KEY: Symbol = symbol_short!("STATS");
 
@@ -109,6 +112,10 @@ pub(crate) const MAX_HISTORY_SIZE: u32 = 1000;
 /// Optional configurable retention limit override. (SC-013)
 /// When set, overrides MAX_HISTORY_SIZE for history trimming.
 pub(crate) const RETENTION_LIMIT_KEY: Symbol = symbol_short!("RETLIM");
+
+/// Cron-style history pruning policy. (#94)
+/// Stores a PrunePolicy struct governing automated history pruning.
+pub(crate) const PRUNE_POLICY_KEY: Symbol = symbol_short!("PRUNPOL");
 
 /// On-chain key storing the ledger sequence of the last config update. Re-exported
 /// here so the storage-key namespace regression test catches any future collisions.
@@ -208,6 +215,9 @@ pub(crate) const EVENT_PRUNED: Symbol = symbol_short!("pruned");
 /// Emitted after a prune_history_by_age call removes entries. (SC-063)
 pub(crate) const EVENT_PRUNED_AGE: Symbol = symbol_short!("pruned_a");
 
+/// Emitted after an apply_prune_policy call removes entries. (#94)
+pub(crate) const EVENT_PRUNED_POLICY: Symbol = symbol_short!("pruned_p");
+
 /// Emitted when a new admin is proposed. (#63)
 pub(crate) const EVENT_ADMIN_PROP: Symbol = symbol_short!("adm_prop");
 
@@ -297,6 +307,8 @@ pub enum SLAError {
     InvalidInput = 17,
     /// Custom severity referenced but not registered. (#93)
     SeverityNotInSet = 18,
+    /// No prune policy has been set when apply_prune_policy was called. (#94)
+    NoPrunePolicy = 19,
 }
 
 // -----------------------------------------------------------------------
@@ -455,6 +467,26 @@ pub struct PauseInfo {
     pub reason: String,
     pub paused_at: u64, // ledger timestamp (seconds)
     pub paused_by: Address,
+}
+
+/// #94 – Cron-style history pruning policy.
+///
+/// Operators can store a PrunePolicy to express high-level retention rules.
+/// The `cron_expr` field is informational — actual execution cadence is
+/// driven externally (e.g., by a cron job calling `apply_prune_policy`).
+/// When `apply_prune_policy` is called, both `keep_latest` (count-based)
+/// and `max_age_seconds` (age-based) pruning are applied if their values
+/// are non-zero.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrunePolicy {
+    /// Number of most recent records to retain (count-based pruning).
+    pub keep_latest: u32,
+    /// Maximum age in seconds before a record is eligible for removal.
+    pub max_age_seconds: u64,
+    /// Cron expression describing the intended pruning schedule.
+    /// This is informational only; execution timing is external.
+    pub cron_expr: String,
 }
 
 /// #4 – Metadata about the most recent configuration update.
@@ -1267,7 +1299,7 @@ impl SLACalculatorContract {
 
         // Emit in numeric order for deterministic consumption
         // All descriptions must be <= 32 bytes (Soroban Symbol constraint)
-        let entries: [(u32, &str, &str); 18] = [
+        let entries: [(u32, &str, &str); 19] = [
             (1, "AlreadyInitialized", "Contract already initialized"),
             (2, "NotInitialized", "Contract not yet initialized"),
             (3, "Unauthorized", "Caller lacks required role"),
@@ -1286,6 +1318,7 @@ impl SLACalculatorContract {
             (16, "ConfigFrozen", "Configuration is frozen"),
             (17, "InvalidInput", "Invalid input parameter"),
             (18, "SeverityNotInSet", "Custom severity not registered"),
+            (19, "NoPrunePolicy", "No pruning policy set"),
         ];
 
         for (code, label, description) in entries {
@@ -1395,6 +1428,7 @@ impl SLACalculatorContract {
         features.push_back(symbol_short!("ver_nego"));
         features.push_back(symbol_short!("corr_id"));
         features.push_back(symbol_short!("freeze"));
+        features.push_back(symbol_short!("prune_pol"));
 
         Ok(ContractMetadata {
             contract_name: symbol_short!("sla_calc"),
@@ -2174,6 +2208,103 @@ impl SLACalculatorContract {
             env.storage().instance().set(&HISTORY_KEY, &new_history);
             env.events()
                 .publish((EVENT_PRUNED_AGE, EVENT_VERSION, caller), (removed, kept));
+        }
+
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // #94 – Cron-style history pruning policy
+    // -------------------------------------------------------------------
+
+    /// Stores a [`PrunePolicy`] in contract storage. Admin only.
+    ///
+    /// The `cron_expr` field is informational — actual pruning cadence is
+    /// driven externally. When `apply_prune_policy` is called, both the
+    /// count-based (`keep_latest`) and age-based (`max_age_seconds`)
+    /// rules are applied if their values are non-zero.
+    pub fn set_prune_policy(env: Env, caller: Address, policy: PrunePolicy) -> Result<(), SLAError> {
+        Self::check_version(&env)?;
+        Self::require_admin(&env, &caller)?;
+
+        if policy.cron_expr.len() > MAX_CRON_EXPR_LEN as u32 {
+            return Err(SLAError::InvalidInput);
+        }
+
+        env.storage().instance().set(&PRUNE_POLICY_KEY, &policy);
+        Ok(())
+    }
+
+    /// Returns the currently stored [`PrunePolicy`], or `None` if no
+    /// policy has been set via `set_prune_policy`.
+    pub fn get_prune_policy(env: Env) -> Result<Option<PrunePolicy>, SLAError> {
+        Self::check_version(&env)?;
+        Ok(env.storage().instance().get(&PRUNE_POLICY_KEY))
+    }
+
+    /// Applies the stored [`PrunePolicy`] against the current history.
+    ///
+    /// Admin only. If no policy has been set via `set_prune_policy`,
+    /// returns [`NoPrunePolicy`](SLAError::NoPrunePolicy).
+    ///
+    /// When a policy is present:
+    /// - If `keep_latest > 0`, count-based pruning is applied first.
+    /// - If `max_age_seconds > 0`, age-based pruning is applied second.
+    /// - A single `pruned_p` event is emitted with aggregate removed/kept counts.
+    ///
+    /// Both pruning stages are independent — both are applied regardless
+    /// of whether the other stage removed any entries.
+    pub fn apply_prune_policy(env: Env, caller: Address) -> Result<(), SLAError> {
+        Self::check_version(&env)?;
+        Self::require_admin(&env, &caller)?;
+
+        let policy: PrunePolicy = env
+            .storage()
+            .instance()
+            .get(&PRUNE_POLICY_KEY)
+            .ok_or(SLAError::NoPrunePolicy)?;
+
+        let mut history: Vec<SLAResult> = env
+            .storage()
+            .instance()
+            .get(&HISTORY_KEY)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let original_len = history.len();
+        let mut total_removed: u32 = 0;
+
+        // Stage 1: count-based pruning (keep_latest)
+        if policy.keep_latest > 0 && history.len() > policy.keep_latest {
+            let remove_count = history.len() - policy.keep_latest;
+            total_removed += remove_count;
+            let mut new_history = Vec::new(&env);
+            for i in remove_count..history.len() {
+                new_history.push_back(history.get(i).unwrap());
+            }
+            history = new_history;
+        }
+
+        // Stage 2: age-based pruning (max_age_seconds)
+        if policy.max_age_seconds > 0 {
+            let now = env.ledger().timestamp();
+            let cutoff = now.saturating_sub(policy.max_age_seconds);
+            let mut new_history = Vec::new(&env);
+            for i in 0..history.len() {
+                let entry = history.get(i).unwrap();
+                if entry.recorded_at >= cutoff {
+                    new_history.push_back(entry);
+                } else {
+                    total_removed += 1;
+                }
+            }
+            history = new_history;
+        }
+
+        if total_removed > 0 {
+            let kept = history.len();
+            env.storage().instance().set(&HISTORY_KEY, &history);
+            env.events()
+                .publish((EVENT_PRUNED_POLICY, EVENT_VERSION, caller), (total_removed, kept));
         }
 
         Ok(())

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -294,6 +294,7 @@ fn test_storage_key_namespace_symbols_are_distinct() {
         HISTORY_KEY,
         STORAGE_VERSION_KEY,
         RETENTION_LIMIT_KEY,
+        PRUNE_POLICY_KEY,
     ];
 
     for i in 0..keys.len() {
@@ -6933,3 +6934,311 @@ fn test_calculate_sla_rejects_unregistered_custom_severity() {
         &45,
     );
 }
+
+// ============================================================
+// #94 – Cron-style history pruning policy
+// ============================================================
+
+#[test]
+fn test_set_get_prune_policy_admin_can_store_and_retrieve() {
+    let (env, client, actors) = setup();
+
+    let policy = PrunePolicy {
+        keep_latest: 50,
+        max_age_seconds: 86400,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 2 * * 0"),
+    };
+
+    client.set_prune_policy(&actors.admin, &policy);
+
+    let stored = client.get_prune_policy().expect("policy should be set");
+    assert_eq!(stored.keep_latest, 50);
+    assert_eq!(stored.max_age_seconds, 86400);
+}
+
+#[test]
+fn test_get_prune_policy_returns_none_when_not_set() {
+    let (_env, client, _actors) = setup();
+
+    let policy = client.get_prune_policy();
+    assert!(policy.is_none(), "Expected None when no policy has been set");
+}
+
+#[test]
+fn test_set_prune_policy_overwrites_previous() {
+    let (env, client, actors) = setup();
+
+    let policy1 = PrunePolicy {
+        keep_latest: 10,
+        max_age_seconds: 3600,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 * * * *"),
+    };
+    client.set_prune_policy(&actors.admin, &policy1);
+
+    let policy2 = PrunePolicy {
+        keep_latest: 20,
+        max_age_seconds: 7200,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 0 * * 0"),
+    };
+    client.set_prune_policy(&actors.admin, &policy2);
+
+    let stored = client.get_prune_policy().expect("policy should be set");
+    assert_eq!(stored.keep_latest, 20);
+    assert_eq!(stored.max_age_seconds, 7200);
+}
+
+#[test]
+#[should_panic]
+fn test_set_prune_policy_operator_cannot() {
+    let (env, client, actors) = setup();
+    let policy = PrunePolicy {
+        keep_latest: 10,
+        max_age_seconds: 0,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 0 * * 0"),
+    };
+    client.set_prune_policy(&actors.operator, &policy);
+}
+
+#[test]
+#[should_panic]
+fn test_set_prune_policy_stranger_cannot() {
+    let (env, client, actors) = setup();
+    let policy = PrunePolicy {
+        keep_latest: 10,
+        max_age_seconds: 0,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 0 * * 0"),
+    };
+    client.set_prune_policy(&actors.stranger, &policy);
+}
+
+#[test]
+fn test_apply_prune_policy_keep_latest_prunes_by_count() {
+    let (env, client, actors) = setup();
+
+    // Generate 10 records
+    for i in 0..10u32 {
+        let oid = Symbol::new(&env, &alloc::format!("PPL_{}", i));
+        client.calculate_sla(&actors.operator, &oid, &symbol_short!("low"), &10);
+    }
+
+    assert_eq!(client.get_history().len(), 10);
+
+    let policy = PrunePolicy {
+        keep_latest: 3,
+        max_age_seconds: 0,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 2 * * 0"),
+    };
+    client.set_prune_policy(&actors.admin, &policy);
+    client.apply_prune_policy(&actors.admin);
+
+    let history = client.get_history();
+    assert_eq!(history.len(), 3, "Should keep only the 3 most recent records");
+}
+
+#[test]
+fn test_apply_prune_policy_max_age_prunes_by_age() {
+    let (env, client, actors) = setup();
+
+    // Set timestamp and create records
+    env.ledger().set_timestamp(1000);
+    for i in 0..5u32 {
+        let oid = Symbol::new(&env, &alloc::format!("PPA_OLD_{}", i));
+        client.calculate_sla(&actors.operator, &oid, &symbol_short!("low"), &10);
+    }
+
+    // Advance time and create newer records
+    env.ledger().set_timestamp(5000);
+    for i in 0..5u32 {
+        let oid = Symbol::new(&env, &alloc::format!("PPA_NEW_{}", i));
+        client.calculate_sla(&actors.operator, &oid, &symbol_short!("low"), &10);
+    }
+
+    assert_eq!(client.get_history().len(), 10);
+
+    // Policy: remove records older than 2000 seconds
+    let policy = PrunePolicy {
+        keep_latest: 0,
+        max_age_seconds: 2000,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 2 * * 0"),
+    };
+    client.set_prune_policy(&actors.admin, &policy);
+    client.apply_prune_policy(&actors.admin);
+
+    let history = client.get_history();
+    // Older batch at ts=1000 is >2000s old from ts=5000, so they get pruned
+    assert_eq!(history.len(), 5, "Should keep only the newer 5 records");
+}
+
+#[test]
+fn test_apply_prune_policy_combined_both_rules() {
+    let (env, client, actors) = setup();
+
+    // Create older records
+    env.ledger().set_timestamp(1000);
+    for i in 0..5u32 {
+        let oid = Symbol::new(&env, &alloc::format!("PCB_OLD_{}", i));
+        client.calculate_sla(&actors.operator, &oid, &symbol_short!("low"), &10);
+    }
+
+    // Create newer records
+    env.ledger().set_timestamp(5000);
+    for i in 0..10u32 {
+        let oid = Symbol::new(&env, &alloc::format!("PCB_NEW_{}", i));
+        client.calculate_sla(&actors.operator, &oid, &symbol_short!("low"), &10);
+    }
+
+    assert_eq!(client.get_history().len(), 15);
+
+    // Policy: keep latest 7 AND remove records older than 2000s
+    let policy = PrunePolicy {
+        keep_latest: 7,
+        max_age_seconds: 2000,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 2 * * 0"),
+    };
+    client.set_prune_policy(&actors.admin, &policy);
+    client.apply_prune_policy(&actors.admin);
+
+    let history = client.get_history();
+    // After age-based pruning: only 10 newer remain
+    // After count-based pruning: keep latest 7 of those 10
+    assert_eq!(history.len(), 7, "Should keep 7 newest after both rules applied");
+}
+
+#[test]
+#[should_panic]
+fn test_apply_prune_policy_fails_when_no_policy_set() {
+    let (_env, client, actors) = setup();
+    // No policy set — should return NoPrunePolicy error
+    client.apply_prune_policy(&actors.admin);
+}
+
+#[test]
+#[should_panic]
+fn test_apply_prune_policy_stranger_cannot() {
+    let (env, client, actors) = setup();
+    let policy = PrunePolicy {
+        keep_latest: 5,
+        max_age_seconds: 0,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 0 * * 0"),
+    };
+    client.set_prune_policy(&actors.admin, &policy);
+    client.apply_prune_policy(&actors.stranger);
+}
+
+#[test]
+#[should_panic]
+fn test_apply_prune_policy_operator_cannot() {
+    let (env, client, actors) = setup();
+    let policy = PrunePolicy {
+        keep_latest: 5,
+        max_age_seconds: 0,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 0 * * 0"),
+    };
+    client.set_prune_policy(&actors.admin, &policy);
+    client.apply_prune_policy(&actors.operator);
+}
+
+#[test]
+fn test_apply_prune_policy_emits_pruned_p_event() {
+    let (env, client, actors) = setup();
+
+    // Generate 5 records
+    for i in 0..5u32 {
+        let oid = Symbol::new(&env, &alloc::format!("PPEV_{}", i));
+        client.calculate_sla(&actors.operator, &oid, &symbol_short!("low"), &10);
+    }
+
+    let policy = PrunePolicy {
+        keep_latest: 2,
+        max_age_seconds: 0,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 2 * * 0"),
+    };
+    client.set_prune_policy(&actors.admin, &policy);
+    client.apply_prune_policy(&actors.admin);
+
+    let events = env.events().all();
+    let (_, topics, data) = events.last().unwrap();
+
+    assert_eq!(topics.len(), 3);
+    let name: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    let version: Symbol = topics.get(1).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(name, symbol_short!("pruned_p"));
+    assert_eq!(version, symbol_short!("v1"));
+
+    let payload: (u32, u32) = data.try_into_val(&env).unwrap();
+    assert_eq!(payload, (3u32, 2u32), "pruned_p payload must be (removed, kept)");
+}
+
+#[test]
+fn test_apply_prune_policy_noop_when_nothing_to_prune() {
+    let (env, client, actors) = setup();
+
+    // Generate 2 records
+    for i in 0..2u32 {
+        let oid = Symbol::new(&env, &alloc::format!("PPNP_{}", i));
+        client.calculate_sla(&actors.operator, &oid, &symbol_short!("low"), &10);
+    }
+
+    let policy = PrunePolicy {
+        keep_latest: 10, // more than current count — no pruning
+        max_age_seconds: 0,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 0 * * 0"),
+    };
+    client.set_prune_policy(&actors.admin, &policy);
+    client.apply_prune_policy(&actors.admin);
+
+    // All records should be retained
+    assert_eq!(client.get_history().len(), 2, "No records should be removed");
+}
+
+#[test]
+fn test_apply_prune_policy_budget_is_reasonable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    let admin = soroban_sdk::Address::generate(&env);
+    let op = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin, &op);
+
+    for i in 0..20u32 {
+        let oid = Symbol::new(&env, &alloc::format!("PPB_{}", i));
+        client.calculate_sla(&op, &oid, &symbol_short!("low"), &10);
+    }
+
+    let policy = PrunePolicy {
+        keep_latest: 5,
+        max_age_seconds: 0,
+        cron_expr: soroban_sdk::String::from_str(&env, "0 0 * * 0"),
+    };
+    client.set_prune_policy(&admin, &policy);
+
+    let before = env.budget().cpu_instruction_cost();
+    client.apply_prune_policy(&admin);
+    let after = env.budget().cpu_instruction_cost();
+
+    assert!(
+        after - before < 900_000,
+        "apply_prune_policy too expensive: {} instructions",
+        after - before
+    );
+}
+
+#[test]
+fn test_get_failure_schema_includes_no_prune_policy() {
+    let (_env, client, _actors) = setup();
+    let schema = client.get_failure_schema();
+
+    let has_no_prune_policy = schema
+        .codes
+        .iter()
+        .any(|c| c.code == 19 && c.label == symbol_short!("NoPrunePolicy"));
+    assert!(
+        has_no_prune_policy,
+        "FailureSchema should include NoPrunePolicy (code 19)"
+    );
+}
+
+


### PR DESCRIPTION
Closes #94

## Summary
Adds a cron-style history-pruning policy helper (`prune_policy`) for high-level retention rules.

## Changes
- **PrunePolicy struct**: stores keep_latest, max_age_seconds, cron_expr
- **set_prune_policy**: store a pruning policy (admin only)
- **get_prune_policy**: retrieve the stored policy
- **apply_prune_policy**: apply the policy against history, removing entries by count and/or age
- **Event pruned_p**: emitted when policy pruning removes entries
- **Error code NoPrunePolicy (19)**: returned when apply_prune_policy is called with no policy set

## Files Changed
- `apexchainx_calculator/src/lib.rs` — PrunePolicy struct, storage key, event, contractimpl methods, feature flag
- `apexchainx_calculator/src/history.rs` — delegate functions for set/get/apply prune policy
- `apexchainx_calculator/src/event_schema.rs` — pruned_p event constant, docs, and test coverage
- `apexchainx_calculator/src/tests.rs` — 13 new tests covering full lifecycle
