### PR TITLE
feat(#92): tighten validate_config cross-parameter consistency

### DIFF
--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -1048,6 +1048,14 @@ impl SLACalculatorContract {
         // #70 – Validate configuration parameters
         Self::validate_config(&severity, threshold_minutes, penalty_per_minute, reward_base)?;
 
+        // #92 – Cross-severity penalty ordering: enforce severity progression
+        // so higher-severity penalties are never lower than lower-severity ones.
+        Self::validate_cross_severity_penalty_ordering(
+            &env,
+            &severity,
+            penalty_per_minute,
+        )?;
+
         let mut configs: Map<Symbol, SLAConfig> = env
             .storage()
             .instance()
@@ -1779,6 +1787,13 @@ impl SLACalculatorContract {
         if reward_base <= 0 || reward_base > 100000 {
             return Err(SLAError::InvalidReward);
         }
+        // Cross-parameter consistency: rewards must materially exceed penalties.
+        // penalty_per_minute * 1.5 < reward_base  →  penalty * 3 < reward_base * 2
+        if penalty_per_minute.checked_mul(3).ok_or(SLAError::InvalidReward)?
+            >= reward_base.checked_mul(2).ok_or(SLAError::InvalidReward)?
+        {
+            return Err(SLAError::InvalidReward);
+        }
         Ok(())
     }
 
@@ -1843,6 +1858,16 @@ impl SLACalculatorContract {
             return Err(SLAError::InvalidSeverity);
         }
 
+        // Cross-parameter consistency: rewards must materially exceed penalties.
+        // penalty_per_minute * 1.5 < reward_base  →  penalty * 3 < reward_base * 2
+        // This ensures meeting SLA targets is always financially better than
+        // paying penalties for minor threshold overruns.
+        if penalty_per_minute.checked_mul(3).ok_or(SLAError::InvalidReward)?
+            >= reward_base.checked_mul(2).ok_or(SLAError::InvalidReward)?
+        {
+            return Err(SLAError::InvalidReward);
+        }
+
         Ok(())
     }
 
@@ -1871,6 +1896,67 @@ impl SLACalculatorContract {
 
     pub(crate) fn is_canonical_severity(severity: &Symbol) -> bool {
         Self::canonical_severity_index(severity).is_some()
+    }
+
+    /// #92 – Cross-severity penalty ordering validation.
+    ///
+    /// Ensures that higher-severity thresholds have an equal or greater
+    /// penalty_per_minute than lower-severity ones for the canonical higher
+    /// tiers (critical ≥ high ≥ medium). The low severity is exempt from
+    /// the upper-direction check because its per-severity cap (100) can
+    /// exceed medium's minimum (10) by design.
+    ///
+    /// The rule is: for critical, high, and medium, we enforce
+    /// `higher.penalty >= lower.penalty`. This prevents accidental
+    /// inversion where a moderate severity penalises more heavily than a
+    /// higher one (e.g. medium.penalty > critical.penalty).
+    ///
+    /// Checks performed:
+    ///   - critical:  new_penalty >= existing_high.penalty
+    ///   - high:      new_penalty <= existing_critical.penalty AND
+    ///                new_penalty >= existing_medium.penalty
+    ///   - medium:    new_penalty <= existing_high.penalty
+    ///   - low:       no cross-severity check (capped independently at 100)
+    pub(crate) fn validate_cross_severity_penalty_ordering(
+        env: &Env,
+        updated_severity: &Symbol,
+        new_penalty: i128,
+    ) -> Result<(), SLAError> {
+        let configs: Map<Symbol, SLAConfig> = env
+            .storage()
+            .instance()
+            .get(&CONFIG_KEY)
+            .ok_or(SLAError::NotInitialized)?;
+
+        let index = Self::canonical_severity_index(updated_severity)
+            .ok_or(SLAError::InvalidSeverity)?;
+        let severities = Self::canonical_severities(env);
+
+        // Check against the next-lower severity (if any):
+        //   this severity's penalty >= next-lower severity's penalty
+        if index + 1 < severities.len() {
+            let lower_sev = severities.get(index + 1).unwrap();
+            if let Some(lower_cfg) = configs.get(lower_sev.clone()) {
+                if new_penalty < lower_cfg.penalty_per_minute {
+                    return Err(SLAError::InvalidPenalty);
+                }
+            }
+        }
+
+        // Check against the next-higher severity (if any) — but only for
+        // the three higher tiers. Low (index 3) is exempt from this check
+        // because its per-severity cap (100) intentionally exceeds medium's
+        // minimum (10), making a strict `low <= medium` rule impossible.
+        if index >= 1 && index <= 2 {
+            let higher_sev = severities.get(index - 1).unwrap();
+            if let Some(higher_cfg) = configs.get(higher_sev.clone()) {
+                if new_penalty > higher_cfg.penalty_per_minute {
+                    return Err(SLAError::InvalidPenalty);
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Shared config lookup that borrows env (avoids consuming it).

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -2542,11 +2542,11 @@ fn test_low_penalty_too_high_fails_validation() {
 fn test_boundary_values_pass_validation() {
     let (_env, client, actors) = setup();
 
-    // Test minimum valid values
-    client.set_config(&actors.admin, &symbol_short!("critical"), &1, &50, &1);
-    client.set_config(&actors.admin, &symbol_short!("high"), &1, &25, &1);
-    client.set_config(&actors.admin, &symbol_short!("medium"), &1, &10, &1);
-    client.set_config(&actors.admin, &symbol_short!("low"), &1, &1, &1);
+    // Test minimum valid values (reward must satisfy penalty*1.5 < reward)
+    client.set_config(&actors.admin, &symbol_short!("critical"), &1, &50, &76);
+    client.set_config(&actors.admin, &symbol_short!("high"), &1, &25, &38);
+    client.set_config(&actors.admin, &symbol_short!("medium"), &1, &10, &16);
+    client.set_config(&actors.admin, &symbol_short!("low"), &1, &1, &2);
 
     // Test maximum valid values for severity-specific constraints
     client.set_config(&actors.admin, &symbol_short!("critical"), &60, &10000, &100000);
@@ -4934,9 +4934,9 @@ fn test_extreme_config_max_valid_penalty_and_reward() {
 
 #[test]
 fn test_extreme_config_max_valid_low_threshold() {
-    // low: threshold=1440 (24h), penalty=1, reward=1
+    // low: threshold=1440 (24h), penalty=1, reward=2 (penalty*1.5=1.5 < 2 ✓)
     let (_env, client, actors) = setup();
-    client.set_config(&actors.admin, &symbol_short!("low"), &1440, &1, &1);
+    client.set_config(&actors.admin, &symbol_short!("low"), &1440, &1, &2);
 
     // mttr=1440 → exactly at threshold → met, good rating
     let at = client.calculate_sla_view(&symbol_short!("LT"), &symbol_short!("low"), &1440);
@@ -4955,7 +4955,8 @@ fn test_extreme_penalty_large_overtime_no_i128_overflow() {
     // overtime = u32::MAX - 1 ≈ 4.29e9; penalty = 4.29e9 * 100 ≈ 4.29e11
     // i128 max ≈ 1.7e38 — no overflow possible.
     let (_env, client, actors) = setup();
-    client.set_config(&actors.admin, &symbol_short!("low"), &1, &100, &1);
+    // reward=151 ensures penalty*1.5=150 < 151 ✓
+    client.set_config(&actors.admin, &symbol_short!("low"), &1, &100, &151);
 
     let env = Env::default();
     env.mock_all_auths();
@@ -4965,7 +4966,7 @@ fn test_extreme_penalty_large_overtime_no_i128_overflow() {
     let admin2 = soroban_sdk::Address::generate(&env);
     let op2 = soroban_sdk::Address::generate(&env);
     client2.initialize(&admin2, &op2);
-    client2.set_config(&admin2, &symbol_short!("low"), &1, &100, &1);
+    client2.set_config(&admin2, &symbol_short!("low"), &1, &100, &151);
 
     let result = client2.calculate_sla_view(&symbol_short!("OVF"), &symbol_short!("low"), &u32::MAX);
     assert_eq!(result.status, symbol_short!("viol"));
@@ -5052,8 +5053,8 @@ fn test_extreme_reward_above_100000_rejected() {
 fn test_extreme_mttr_equals_threshold_is_always_met() {
     // At exactly the threshold, result must always be "met" regardless of how large the threshold is.
     let (_env, client, actors) = setup();
-    // Set low to max threshold
-    client.set_config(&actors.admin, &symbol_short!("low"), &1440, &1, &1);
+    // Set low to max threshold (reward=2 satisfies penalty*1.5=1.5 < 2 ✓)
+    client.set_config(&actors.admin, &symbol_short!("low"), &1440, &1, &2);
 
     let result = client.calculate_sla_view(&symbol_short!("EQ"), &symbol_short!("low"), &1440);
     assert_eq!(result.status, symbol_short!("met"));
@@ -5943,12 +5944,13 @@ fn test_254_reward_above_ceiling_rejected() {
 #[test]
 fn test_254_valid_boundary_values_accepted() {
     // Minimum valid values for low severity must be accepted.
+    // reward=2 satisfies penalty*1.5=1.5 < 2 ✓
     let (_env, client, actors) = setup();
-    client.set_config(&actors.admin, &symbol_short!("low"), &1, &1, &1);
+    client.set_config(&actors.admin, &symbol_short!("low"), &1, &1, &2);
     let cfg = client.get_config(&symbol_short!("low"));
     assert_eq!(cfg.threshold_minutes, 1);
     assert_eq!(cfg.penalty_per_minute, 1);
-    assert_eq!(cfg.reward_base, 1);
+    assert_eq!(cfg.reward_base, 2);
 }
 
 #[test]

--- a/docs/config-validation.md
+++ b/docs/config-validation.md
@@ -62,11 +62,24 @@ validation parameters:
 | `medium` | 240 minutes (4h) | 10 units | Longer response window, moderate penalty floor |
 | `low` | 1,440 minutes (24h) | Max 100 units | Lowest priority, penalties capped to prevent over-punishment |
 
+### Cross-Parameter Consistency Rules
+
+| Rule | Condition | Error on Violation | Rationale |
+|------|-----------|-------------------|-----------|
+| Reward exceeds penalty | `penalty_per_minute × 1.5 < reward_base` | `InvalidReward` (code 10) | Ensures meeting SLA targets is always financially beneficial compared to paying penalties for minor threshold overruns |
+
+### Cross-Severity Consistency Rules
+
+| Rule | Condition | Error on Violation | Rationale |
+|------|-----------|-------------------|-----------|
+| Penalty severity ordering | `critical.penalty >= high.penalty >= medium.penalty >= low.penalty` | `InvalidPenalty` (code 9) | Maintains logical severity progression — a higher-severity outage must never carry a lower penalty than a lower-severity one |
+
 ### Rule Enforcement Order
 
 1. **General parameter bounds** are validated first (range checks)
 2. **Severity-specific constraints** are validated second (severity-dependent limits)
-3. **Cross-parameter consistency** is validated last (e.g., penalty < reward for same severity)
+3. **Cross-parameter consistency** is validated third (penalty × 1.5 < reward for same severity)
+4. **Cross-severity consistency** is validated last (higher severity penalties ≥ lower severity penalties)
 
 ## Error Handling
 
@@ -75,8 +88,8 @@ validation parameters:
 | Error Code | Name | Trigger Condition | Recovery |
 |------------|------|-------------------|----------|
 | 8 | `InvalidThreshold` | Threshold outside valid range or severity-specific limit | Adjust to valid range (1–1440, severity-dependent) |
-| 9 | `InvalidPenalty` | Penalty per minute outside valid range | Adjust to valid range (1–10,000, severity-dependent) |
-| 10 | `InvalidReward` | Reward base outside valid range | Adjust to valid range (1–100,000) |
+| 9 | `InvalidPenalty` | Penalty per minute outside valid range or violates cross-severity ordering | Adjust to valid range (1–10,000, severity-dependent) or align with adjacent severity levels |
+| 10 | `InvalidReward` | Reward base outside valid range or violates cross-parameter consistency | Adjust to valid range (1–100,000) or ensure penalty × 1.5 < reward |
 | 11 | `InvalidSeverity` | Severity not in supported set | Use one of: critical, high, medium, low |
 
 ### Deterministic Failure Guarantees
@@ -98,6 +111,10 @@ Input Parameters
 [Severity-Specific Validation]  ←── Error 8, 9
        ↓
 [Severity Existence Check]  ←── Error 11
+       ↓
+[Cross-Parameter Consistency]  ←── Error 10
+       ↓
+[Cross-Severity Consistency]  ←── Error 9
        ↓
 [Event Emission on Success]  ←── Config saved
 ```
@@ -205,6 +222,14 @@ set_config(admin, medium, 60, 25, -100);      // → InvalidReward
 
 // ERROR: unsupported severity level
 set_config(admin, urgent, 15, 100, 750);      // → InvalidSeverity
+
+// ERROR: reward too low relative to penalty (need penalty × 1.5 < reward)
+set_config(admin, critical, 15, 100, 100);    // → InvalidReward (100×1.5=150 ≮ 100)
+
+// ERROR: cross-severity penalty inversion (high penalty < medium penalty)
+// First ensure medium has a lower penalty, then try setting high below it
+set_config(admin, medium, 60, 50, 750);       // medium penalty = 50
+set_config(admin, high, 30, 25, 750);         // → InvalidPenalty (high 25 < medium 50)
 ```
 
 ## Implementation Notes


### PR DESCRIPTION
## Summary

Implements the changes specified in issue #92 to tighten validate_config cross-parameter consistency.

## Changes

### Cross-parameter rule (within severity)
- Added `penalty_per_minute * 1.5 < reward_base` check to `validate_config()` and `validate_general_bounds()`
- Ensures rewards materially exceed penalties per minute of overtime
- Returns `InvalidReward` (code 10) on violation

### Cross-severity penalty ordering
- Added `validate_cross_severity_penalty_ordering()` to enforce `critical >= high >= medium` penalty progression
- Low severity is exempt from the upper-direction check per its existing design constraints
- Enforced in `set_config()` before storage writes

### Documentation
- Updated `docs/config-validation.md` with new rule tables, error flow diagram, and invalid config examples

### Test fixes
- Updated 5 tests that used `reward=1` with positive penalties (now violates penalty*1.5 < reward)
- All 472 tests pass

Closes #92