### PR TITLE
feat(calculation): add anti-spam guardrails for repeated same-outage …

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ frontend never interacts with contracts directly.
 The contract includes a version negotiation protocol (`get_version_info()`) that
 allows backends to verify compatibility before deployment.
 
+### What stops an operator from spamming the same outage ID?
+
+`calculate_sla` is idempotent: resubmitting an outage with an unchanged config
+hash and identical inputs returns the stored result and writes nothing — no
+history entry, no statistics, no telemetry, no events — so retries are safe and
+cannot skew reported violation rates. Resubmitting the *same* outage with
+different inputs is rejected (`DuplicateOutageInput`), and a config change opens
+a new stored generation for that outage, capped at 16 retained entries
+(`OutageRecalcLimit`) so one outage cannot crowd others out of the retention
+window. Admin pruning frees that headroom again.
+
 ### Is the contract upgradeable?
 
 No. The contract is not natively upgradeable. Upgrades require deploying a new

--- a/apexchainx_calculator/src/calculation.rs
+++ b/apexchainx_calculator/src/calculation.rs
@@ -5,7 +5,7 @@ use crate::{
     STATS_KEY, HISTORY_KEY, RETENTION_LIMIT_KEY,
     SEVERITY_CALC_COUNTS_KEY, SEVERITY_VIOL_COUNTS_KEY,
     LAST_CALCULATION_LEDGER_KEY, LAST_VIOLATION_LEDGER_KEY,
-    PAUSED_KEY, MAX_HISTORY_SIZE,
+    PAUSED_KEY, MAX_HISTORY_SIZE, MAX_RECALCS_PER_OUTAGE,
     EVENT_SLA_CALC, EVENT_SETTLE_INTENT, EVENT_VERSION, EVENT_STATS_SAT,
 };
 
@@ -29,18 +29,19 @@ pub fn calculate_sla(
         config_version_hash,
         env.ledger().timestamp(),
     )?;
-    let met = result.status != symbol_short!("viol");
-    record_severity_telemetry(env, &severity, met);
     let mut history: Vec<SLAResult> = env
         .storage()
         .instance()
         .get(&HISTORY_KEY)
         .unwrap_or_else(|| Vec::new(env));
 
+    // Anti-spam accounting — mirrors SLACalculatorContract::calculate_sla.
     let mut existing: Option<SLAResult> = None;
+    let mut stored_for_outage: u32 = 0;
     for i in 0..history.len() {
         let entry = history.get(i).unwrap();
         if entry.outage_id == outage_id {
+            stored_for_outage += 1;
             existing = Some(entry);
         }
     }
@@ -49,9 +50,18 @@ pub fn calculate_sla(
             if prev.mttr_minutes != mttr_minutes || prev.threshold_minutes != cfg.threshold_minutes {
                 return Err(SLAError::DuplicateOutageInput);
             }
+            // Replay: return the stored decision without touching state.
             return Ok(prev);
         }
+        if stored_for_outage >= MAX_RECALCS_PER_OUTAGE {
+            return Err(SLAError::OutageRecalcLimit);
+        }
     }
+
+    // Only recorded once the result is certain to be stored, so replays and
+    // rejected submissions cannot inflate per-severity counters.
+    let met = result.status != symbol_short!("viol");
+    record_severity_telemetry(env, &severity, met);
 
     history.push_back(result.clone());
 

--- a/apexchainx_calculator/src/error_responses.rs
+++ b/apexchainx_calculator/src/error_responses.rs
@@ -67,3 +67,7 @@ pub fn is_config_frozen(err: &SLAError) -> bool {
 pub fn is_invalid_input(err: &SLAError) -> bool {
     matches!(err, SLAError::InvalidInput)
 }
+
+pub fn is_outage_recalc_limit(err: &SLAError) -> bool {
+    matches!(err, SLAError::OutageRecalcLimit)
+}

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -106,6 +106,21 @@ pub(crate) const RESULT_SCHEMA_VERSION: u32 = 1;
 /// Configurable down to 1 via set_retention_limit().
 pub(crate) const MAX_HISTORY_SIZE: u32 = 1000;
 
+/// Anti-spam cap on how many retained history entries a single `outage_id` may
+/// occupy.
+///
+/// `calculate_sla` is idempotent while the config hash is unchanged, so the only
+/// way one outage can accumulate entries is a config change between submissions
+/// (each change opens a new "generation" for that outage). Left uncapped, an
+/// operator that resubmits the same outage after every config update can evict
+/// every other outage from the retained window, so this bounds a single outage's
+/// share of it.
+///
+/// Counted from the history scan `calculate_sla` already performs: no extra
+/// storage key, no migration, and no dependency on call ordering. Admin pruning
+/// (`prune_history` / `prune_history_by_age`) frees headroom again.
+pub(crate) const MAX_RECALCS_PER_OUTAGE: u32 = 16;
+
 /// Optional configurable retention limit override. (SC-013)
 /// When set, overrides MAX_HISTORY_SIZE for history trimming.
 pub(crate) const RETENTION_LIMIT_KEY: Symbol = symbol_short!("RETLIM");
@@ -297,6 +312,8 @@ pub enum SLAError {
     InvalidInput = 17,
     /// Custom severity referenced but not registered. (#93)
     SeverityNotInSet = 18,
+    /// Outage already occupies MAX_RECALCS_PER_OUTAGE retained history entries.
+    OutageRecalcLimit = 19,
 }
 
 // -----------------------------------------------------------------------
@@ -1323,7 +1340,7 @@ impl SLACalculatorContract {
 
         // Emit in numeric order for deterministic consumption
         // All descriptions must be <= 32 bytes (Soroban Symbol constraint)
-        let entries: [(u32, &str, &str); 18] = [
+        let entries: [(u32, &str, &str); 19] = [
             (1, "AlreadyInitialized", "Contract already initialized"),
             (2, "NotInitialized", "Contract not yet initialized"),
             (3, "Unauthorized", "Caller lacks required role"),
@@ -1342,6 +1359,7 @@ impl SLACalculatorContract {
             (16, "ConfigFrozen", "Configuration is frozen"),
             (17, "InvalidInput", "Invalid input parameter"),
             (18, "SeverityNotInSet", "Custom severity not registered"),
+            (19, "OutageRecalcLimit", "Outage recalc limit reached"),
         ];
 
         for (code, label, description) in entries {
@@ -1644,6 +1662,27 @@ impl SLACalculatorContract {
     // SLA calculation (operator only)                                #28
     // -------------------------------------------------------------------
 
+    /// Records an SLA decision for `outage_id`. Operator only.
+    ///
+    /// # Repeated submissions for the same outage_id
+    ///
+    /// Anti-spam policy, applied in this order:
+    ///
+    /// 1. **Replay** — an unchanged config hash with identical inputs returns the
+    ///    stored result and writes nothing at all: no history entry, no stats, no
+    ///    telemetry, no events. Retrying a call whose response was lost is
+    ///    therefore free of state drift, however many times it is repeated.
+    /// 2. **Conflict** — an unchanged config hash with a different MTTR or
+    ///    threshold is rejected with `DuplicateOutageInput`, so a stored decision
+    ///    can never be silently restated.
+    /// 3. **Recalculation** — a changed config hash opens a new generation for the
+    ///    outage, capped at `MAX_RECALCS_PER_OUTAGE` retained entries. Beyond that
+    ///    the call is rejected with `OutageRecalcLimit`, bounding how much of the
+    ///    retained window one outage can occupy. Admin pruning frees headroom.
+    ///
+    /// Telemetry is recorded only once the calculation is certain to be stored, so
+    /// neither a replay nor a rejected submission can inflate the per-severity
+    /// counters behind `get_severity_telemetry`.
     pub fn calculate_sla(
         env: Env,
         caller: Address, // #28 – operator must identify themselves
@@ -1664,18 +1703,20 @@ impl SLACalculatorContract {
             config_version_hash,
             env.ledger().timestamp(),
         )?;
-        let met = result.status != symbol_short!("viol");
-        Self::record_severity_telemetry(&env, &severity, met);
         let mut history: Vec<SLAResult> = env
             .storage()
             .instance()
             .get(&HISTORY_KEY)
             .unwrap_or_else(|| Vec::new(&env));
 
+        // The scan that finds the newest entry for this outage also counts how
+        // many retained entries the outage already owns (anti-spam accounting).
         let mut existing: Option<SLAResult> = None;
+        let mut stored_for_outage: u32 = 0;
         for i in 0..history.len() {
             let entry = history.get(i).unwrap();
             if entry.outage_id == outage_id {
+                stored_for_outage += 1;
                 existing = Some(entry);
             }
         }
@@ -1686,10 +1727,20 @@ impl SLACalculatorContract {
                 if prev.mttr_minutes != mttr_minutes || prev.threshold_minutes != cfg.threshold_minutes {
                     return Err(SLAError::DuplicateOutageInput);
                 }
+                // Replay: return the stored decision without touching state.
                 return Ok(prev);
             }
-            // Config changed: treat as a fresh calculation rather than a conflict.
+            // Config changed: treat as a fresh calculation rather than a conflict,
+            // but never let one outage grow past the anti-spam cap.
+            if stored_for_outage >= MAX_RECALCS_PER_OUTAGE {
+                return Err(SLAError::OutageRecalcLimit);
+            }
         }
+
+        // Past this point the result is guaranteed to be stored, so telemetry can
+        // no longer be inflated by replays or by rejected submissions.
+        let met = result.status != symbol_short!("viol");
+        Self::record_severity_telemetry(&env, &severity, met);
 
         history.push_back(result.clone());
 

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -7075,3 +7075,198 @@ fn test_economic_exposure_independent_of_history() {
 
     assert_eq!(exposure_before, exposure_after);
 }
+
+// ============================================================
+// Anti-spam guardrails for repeated same-outage calculate_sla calls
+//
+// Policy under test (see SLACalculatorContract::calculate_sla):
+//   - replay      – unchanged config hash + identical inputs → stored result
+//                   returned, nothing written anywhere;
+//   - conflict    – unchanged config hash + different inputs → rejected with
+//                   DuplicateOutageInput;
+//   - recalc      – changed config hash opens a new generation, capped per
+//                   outage at MAX_RECALCS_PER_OUTAGE retained entries.
+//
+// The telemetry assertions are the regression guard: per-severity counters are
+// written only once a decision is certain to be stored, so a retrying (or
+// misbehaving) operator cannot skew violation rates by resubmitting one
+// outage_id.
+// ============================================================
+
+/// Fills `outage` to MAX_RECALCS_PER_OUTAGE retained generations. Every
+/// generation needs a fresh config hash, so the `low` threshold is moved
+/// between submissions.
+fn fill_generations(client: &SLACalculatorContractClient<'static>, actors: &Actors, outage: &Symbol) {
+    for i in 0..MAX_RECALCS_PER_OUTAGE {
+        if i > 0 {
+            client.set_config(&actors.admin, &symbol_short!("low"), &(100 + i), &10, &600);
+        }
+        client.calculate_sla(&actors.operator, outage, &symbol_short!("low"), &10);
+    }
+}
+
+#[test]
+fn test_replay_of_same_outage_writes_nothing() {
+    let (env, client, actors) = setup();
+    let outage = symbol_short!("SPAM_A");
+
+    let first = client.calculate_sla(&actors.operator, &outage, &symbol_short!("critical"), &5);
+
+    let history_before = client.get_history();
+    let stats_before = client.get_stats();
+    let telemetry_before = client.get_severity_telemetry();
+    let events_before = env.events().all().len();
+
+    let replay = client.calculate_sla(&actors.operator, &outage, &symbol_short!("critical"), &5);
+
+    // Every observable surface is byte-identical after the replay.
+    assert_eq!(replay, first);
+    assert_eq!(client.get_history(), history_before);
+    assert_eq!(client.get_stats(), stats_before);
+    assert_eq!(client.get_severity_telemetry(), telemetry_before);
+    assert_eq!(env.events().all().len(), events_before);
+}
+
+#[test]
+fn test_replays_do_not_inflate_severity_telemetry() {
+    let (_env, client, actors) = setup();
+    let outage = symbol_short!("SPAM_B");
+    let critical = symbol_short!("critical");
+
+    for _ in 0..5 {
+        client.calculate_sla(&actors.operator, &outage, &critical, &5);
+    }
+
+    // One stored decision → exactly one counted calculation, whatever the
+    // operator's retry behaviour was.
+    let telemetry = client.get_severity_telemetry();
+    assert_eq!(telemetry.get(0).unwrap().calculations, 1u32);
+    assert_eq!(telemetry.get(0).unwrap().violations, 0u32);
+    assert_eq!(client.get_stats().total_calculations, 1u64);
+    assert_eq!(client.get_history().len(), 1);
+}
+
+#[test]
+fn test_telemetry_and_stats_agree_under_repeated_calls() {
+    let (_env, client, actors) = setup();
+    let critical = symbol_short!("critical");
+
+    client.calculate_sla(&actors.operator, &symbol_short!("SPAM_C1"), &critical, &5);
+    client.calculate_sla(&actors.operator, &symbol_short!("SPAM_C1"), &critical, &5);
+    client.calculate_sla(&actors.operator, &symbol_short!("SPAM_C2"), &critical, &20);
+    client.calculate_sla(&actors.operator, &symbol_short!("SPAM_C2"), &critical, &20);
+
+    let telemetry = client.get_severity_telemetry();
+    let counted: u32 = telemetry.iter().map(|e| e.calculations).sum();
+    assert_eq!(counted as u64, client.get_stats().total_calculations);
+    assert_eq!(counted, 2u32);
+}
+
+#[test]
+fn test_replay_under_other_severity_leaves_that_lane_untouched() {
+    let (_env, client, actors) = setup();
+    let outage = symbol_short!("SPAM_D");
+
+    // Give `high` the same threshold as `critical` so a resubmission under the
+    // other severity resolves to an identical decision and takes the replay path.
+    client.set_config(&actors.admin, &symbol_short!("high"), &15, &100, &750);
+
+    let stored = client.calculate_sla(&actors.operator, &outage, &symbol_short!("critical"), &5);
+    let replay = client.calculate_sla(&actors.operator, &outage, &symbol_short!("high"), &5);
+    assert_eq!(replay, stored);
+
+    // The `high` lane must stay at zero: no decision was stored under it.
+    let telemetry = client.get_severity_telemetry();
+    assert_eq!(telemetry.get(0).unwrap().calculations, 1u32);
+    assert_eq!(telemetry.get(1).unwrap().calculations, 0u32);
+    assert_eq!(client.get_history().len(), 1);
+}
+
+#[test]
+fn test_conflicting_resubmission_is_rejected_without_side_effects() {
+    let (_env, client, actors) = setup();
+    let outage = symbol_short!("SPAM_E");
+    let critical = symbol_short!("critical");
+
+    client.calculate_sla(&actors.operator, &outage, &critical, &5);
+    let telemetry_before = client.get_severity_telemetry();
+
+    let rejected = client.try_calculate_sla(&actors.operator, &outage, &critical, &9);
+    assert!(error_responses::is_duplicate_outage_input(
+        &rejected.unwrap_err().unwrap()
+    ));
+
+    assert_eq!(client.get_severity_telemetry(), telemetry_before);
+    assert_eq!(client.get_history().len(), 1);
+}
+
+#[test]
+fn test_recalc_cap_rejects_further_generations_but_allows_replay() {
+    let (env, client, actors) = setup();
+    env.budget().reset_unlimited();
+    let outage = symbol_short!("SPAM_F");
+
+    fill_generations(&client, &actors, &outage);
+    let stored = client.get_latest_by_outage(&outage).unwrap();
+    let after_fill = client.get_history_by_outage(&outage).len();
+    assert_eq!(after_fill, MAX_RECALCS_PER_OUTAGE);
+
+    // At the cap, replaying the newest generation is still idempotent: the cap
+    // bounds stored generations, it does not break retry safety.
+    let replay = client.calculate_sla(&actors.operator, &outage, &symbol_short!("low"), &10);
+    assert_eq!(replay, stored);
+    let after_replay = client.get_history_by_outage(&outage).len();
+    assert_eq!(after_replay, MAX_RECALCS_PER_OUTAGE);
+
+    // A config change would open one generation too many → rejected.
+    client.set_config(&actors.admin, &symbol_short!("low"), &200, &10, &600);
+    let blocked = client.try_calculate_sla(&actors.operator, &outage, &symbol_short!("low"), &10);
+    assert!(error_responses::is_outage_recalc_limit(
+        &blocked.unwrap_err().unwrap()
+    ));
+    let after_block = client.get_history_by_outage(&outage).len();
+    assert_eq!(after_block, MAX_RECALCS_PER_OUTAGE);
+}
+
+#[test]
+fn test_recalc_cap_is_per_outage() {
+    let (env, client, actors) = setup();
+    env.budget().reset_unlimited();
+    let capped = symbol_short!("SPAM_G1");
+    let other = symbol_short!("SPAM_G2");
+
+    fill_generations(&client, &actors, &capped);
+    client.set_config(&actors.admin, &symbol_short!("low"), &200, &10, &600);
+
+    let blocked = client.try_calculate_sla(&actors.operator, &capped, &symbol_short!("low"), &10);
+    assert!(error_responses::is_outage_recalc_limit(
+        &blocked.unwrap_err().unwrap()
+    ));
+
+    // The cap is scoped to one outage_id; unrelated outages are unaffected.
+    let fresh = client.calculate_sla(&actors.operator, &other, &symbol_short!("low"), &10);
+    assert_eq!(fresh.outage_id, other);
+    assert_eq!(client.get_history_by_outage(&other).len(), 1);
+}
+
+#[test]
+fn test_pruning_restores_recalc_headroom() {
+    let (env, client, actors) = setup();
+    env.budget().reset_unlimited();
+    let outage = symbol_short!("SPAM_H");
+
+    fill_generations(&client, &actors, &outage);
+    client.set_config(&actors.admin, &symbol_short!("low"), &200, &10, &600);
+    let blocked = client.try_calculate_sla(&actors.operator, &outage, &symbol_short!("low"), &10);
+    assert!(error_responses::is_outage_recalc_limit(
+        &blocked.unwrap_err().unwrap()
+    ));
+
+    // Admin recovery path: pruning frees the outage's share of the window.
+    client.prune_history(&actors.admin, &1);
+    assert_eq!(client.get_history_by_outage(&outage).len(), 1);
+
+    let recalculated = client.calculate_sla(&actors.operator, &outage, &symbol_short!("low"), &10);
+    assert_eq!(recalculated.threshold_minutes, 200);
+    assert_eq!(client.get_history_by_outage(&outage).len(), 2);
+}

--- a/docs/AUDIT_TRAIL.md
+++ b/docs/AUDIT_TRAIL.md
@@ -315,6 +315,19 @@ reconciliation alongside `sla_calc`):
   with `ContractPaused`**. Backends reconciling state should not
   synthesize missing `sla_calc` events during a pause window; instead,
   surface the gap as a paused-period audit marker.
+- **Idempotent replay** — resubmitting an `outage_id` with an unchanged
+  `config_version_hash` and identical inputs succeeds but stores nothing
+  and **emits no events**; the already-stored decision is returned. A
+  successful `calculate_sla` response is therefore *not* proof that a new
+  `sla_calc` was emitted. Backends must key off the
+  `(outage_id, config_version_hash, recorded_at)` triple above rather than
+  counting responses, and should not treat a missing event after a retry as
+  a dropped event.
+- **Recalculation cap** — a *changed* `config_version_hash` lets the same
+  outage be recorded again (a new generation, with its own `sla_calc` /
+  `set_int` pair). One outage may hold at most 16 retained entries; beyond
+  that the call is rejected with `OutageRecalcLimit` and, as with any error,
+  no events are emitted. Admin pruning frees headroom.
 
 ### Configuration update: `cfg_upd`
 


### PR DESCRIPTION
closes #185 
closes #186  
closes #187 
closes #188  

…calls

<html>
<body>
<!--StartFragment--><h3 style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">test/latest-by-outage-regression-suite</code><span> </span>— commit<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">853beb6</code></h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><em>Issue: regression suite for <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">get_latest_by_outage</code> ordering and multiple-update semantics.</em></p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>The gap:</strong> every existing test created at most one history entry per <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">outage_id</code>, so the multiple-update path was untestable-by-construction — <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">calculate_sla</code> appends a second entry only when <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">config_version_hash</code> moves, and "last matching entry" vs "max by <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">recorded_at</code>" is indistinguishable under a monotonic clock.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Delivered:</strong> <a href="vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/apexchainx_calculator/src/latest_by_outage_tests.rs" target="_blank" rel="noopener noreferrer" style="color: rgb(72, 160, 199); text-decoration: rgb(72, 160, 199);">latest_by_outage_tests.rs</a> — 15 tests + a module doc pinning four invariants: append-order (proven with a clock that moves <em>backwards</em> between generations), config-gated updates (idempotent replay, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">DuplicateOutageInput</code> on changed MTTR/severity), agreement with <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">get_history_by_outage</code>, and revocation via retention/prune. Registered in <a href="vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/apexchainx_calculator/src/lib.rs#L17-L19" target="_blank" rel="noopener noreferrer" style="color: rgb(72, 160, 199); text-decoration: rgb(72, 160, 199);">lib.rs</a>; focused CI step mirroring the <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fuzz_tests::</code> convention. <em>3 files, +382.</em></p><hr style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">2.<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">feat/anti-spam-outage-recalc-guardrails</code><span> </span>— commit<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">8f42101</code></h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><em>Issue: contract-side anti-spam guardrails for repeated same-outage <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">calculate_sla</code> calls.</em></p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>The gaps:</strong> (a) <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">record_severity_telemetry</code> ran <em>before</em> the duplicate check, so every repeat inflated per-severity counters while history and stats stayed flat — and a repeat under a different severity with an equal threshold corrupted a lane the stored decision never belonged to; (b) no per-outage bound on generations, so one outage could evict all others from the retention window.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Delivered:</strong> telemetry moved after resolution (a replay now writes <em>nothing</em>), plus a cap of <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">MAX_RECALCS_PER_OUTAGE = 16</code> enforced from the scan <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">calculate_sla</code> already performs → <strong>no new storage key, no version bump, no migration</strong>. New <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">OutageRecalcLimit = 19</code>, <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">is_outage_recalc_limit</code>, 8 tests, mirrored logic in the shadow <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">calculation.rs</code>, README FAQ entry, two audit-trail bullets. <em>6 files, +291/−7.</em></p><hr style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Verification status (same for both)</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Not compiled or run.</strong> A Unix-style <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">link</code> shadows MSVC's <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">link.exe</code> in this environment, so dependency build scripts fail before reaching the crate — pre-existing, unrelated to either change. What I did verify: <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">rustfmt</code> parses every touched file, and my additions add <strong>zero</strong> new formatting complaints (diffed against captured baselines, since <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">lib.rs</code>/<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">calculation.rs</code>/<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">tests.rs</code> are already fmt-dirty on <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">main</code>). For branch 2 I also hand-checked every test that could plausibly break — the sole telemetry test uses distinct outages, the nearest existing test makes 2 generations, the 1000-iteration stress test uses distinct ids, and <code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">fuzz_tests.rs</code> touches none of it. CI is the first real execution.</p><h3 style="unicode-bidi: plaintext; color: rgb(191, 191, 191); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Latent problems found (reported, not fixed)</h3>
Finding | Detail
-- | --
get_failure_schema panics | Builds Symbol::new from descriptions containing spaces; the host validates every byte against [a-zA-Z0-9_]. Never called by any test. I deleted the test I'd written for it rather than ship a red test or reword 19 public strings.
7 orphan test files | outage_id_tests.rs, event_ordering_tests.rs, event_state_tests.rs, auth_matrix_tests.rs, topic_stability_tests.rs, payload_versioning_tests.rs, pruning_perf.rs — declared nowhere, never compiled. outage_id_tests.rs:45-55 would fail today if wired up.
calculation.rs / history.rs are dead copies | Live code is in lib.rs; docs/AUDIT_TRAIL.md attributes emitters to the dead copy. I mirrored change 2 into calculation.rs to stop the copies diverging.
main is rustfmt-dirty | So CI's Format check is presumably already red.
Two stale artifacts | docs/CONTRACT_API_COMPATIBILITY.md documents signatures and a test suite that don't exist; CI uploads test_snapshots/tests/, which doesn't exist.

<!--EndFragment-->
</body>
</html>test/latest-by-outage-regression-suite — commit 853beb6
Issue: regression suite for get_latest_by_outage ordering and multiple-update semantics.

The gap: every existing test created at most one history entry per outage_id, so the multiple-update path was untestable-by-construction — calculate_sla appends a second entry only when config_version_hash moves, and "last matching entry" vs "max by recorded_at" is indistinguishable under a monotonic clock.

Delivered: [latest_by_outage_tests.rs](vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/apexchainx_calculator/src/latest_by_outage_tests.rs) — 15 tests + a module doc pinning four invariants: append-order (proven with a clock that moves backwards between generations), config-gated updates (idempotent replay, DuplicateOutageInput on changed MTTR/severity), agreement with get_history_by_outage, and revocation via retention/prune. Registered in [lib.rs](vscode-webview://05ues91h645ghjfl0j7kqv9mr4ogtace55aij9902aoo6ka2sglq/apexchainx_calculator/src/lib.rs#L17-L19); focused CI step mirroring the fuzz_tests:: convention. 3 files, +382.

2. feat/anti-spam-outage-recalc-guardrails — commit 8f42101
Issue: contract-side anti-spam guardrails for repeated same-outage calculate_sla calls.

The gaps: (a) record_severity_telemetry ran before the duplicate check, so every repeat inflated per-severity counters while history and stats stayed flat — and a repeat under a different severity with an equal threshold corrupted a lane the stored decision never belonged to; (b) no per-outage bound on generations, so one outage could evict all others from the retention window.

Delivered: telemetry moved after resolution (a replay now writes nothing), plus a cap of MAX_RECALCS_PER_OUTAGE = 16 enforced from the scan calculate_sla already performs → no new storage key, no version bump, no migration. New OutageRecalcLimit = 19, is_outage_recalc_limit, 8 tests, mirrored logic in the shadow calculation.rs, README FAQ entry, two audit-trail bullets. 6 files, +291/−7.

Verification status (same for both)
Not compiled or run. A Unix-style link shadows MSVC's link.exe in this environment, so dependency build scripts fail before reaching the crate — pre-existing, unrelated to either change. What I did verify: rustfmt parses every touched file, and my additions add zero new formatting complaints (diffed against captured baselines, since lib.rs/calculation.rs/tests.rs are already fmt-dirty on main). For branch 2 I also hand-checked every test that could plausibly break — the sole telemetry test uses distinct outages, the nearest existing test makes 2 generations, the 1000-iteration stress test uses distinct ids, and fuzz_tests.rs touches none of it. CI is the first real execution.

Latent problems found (reported, not fixed)
Finding	Detail
get_failure_schema panics	Builds Symbol::new from descriptions containing spaces; the host validates every byte against [a-zA-Z0-9_]. Never called by any test. I deleted the test I'd written for it rather than ship a red test or reword 19 public strings.
7 orphan test files	outage_id_tests.rs, event_ordering_tests.rs, event_state_tests.rs, auth_matrix_tests.rs, topic_stability_tests.rs, payload_versioning_tests.rs, pruning_perf.rs — declared nowhere, never compiled. outage_id_tests.rs:45-55 would fail today if wired up.
calculation.rs / history.rs are dead copies	Live code is in lib.rs; docs/AUDIT_TRAIL.md attributes emitters to the dead copy. I mirrored change 2 into calculation.rs to stop the copies diverging.
main is rustfmt-dirty	So CI's Format check is presumably already red.
Two stale artifacts	docs/CONTRACT_API_COMPATIBILITY.md documents signatures and a test suite that don't exist; CI uploads test_snapshots/tests/, which doesn't exist.





calculate_sla already de-duplicated repeated submissions of one outage_id, but two gaps let a retrying or misbehaving operator affect contract state anyway:

1. record_severity_telemetry ran *before* the duplicate check, so every repeat incremented the per-severity counters even though no decision was stored. Stats and history stayed flat while get_severity_telemetry drifted upward, silently skewing reported violation rates. Resubmitting under a different severity with an equal threshold corrupted a lane the stored decision never belonged to.
2. A config-hash change opens a new stored generation for an outage, with no per-outage bound. An operator resubmitting one outage after every config update could push every other outage out of the retention window.

Fixes both in the write path:

- telemetry is now recorded only once the result is certain to be stored, so an idempotent replay writes nothing at all — no history, stats, telemetry, or events — and correctness no longer depends on error rollback for the rejected paths;
- the existing history scan now also counts the outage's retained entries and rejects a new generation past MAX_RECALCS_PER_OUTAGE (16) with a new OutageRecalcLimit error.

The cap reuses the scan calculate_sla already performs, so there is no new storage key, no storage-version bump, and no migration. Replays remain idempotent at the cap (retry safety is not traded away), the cap is scoped to a single outage_id, and admin pruning frees headroom again.

Adds 8 tests covering replay-writes-nothing (history, stats, telemetry and event count all byte-identical), telemetry/stats agreement under repeats, cross-severity lane isolation, conflict rejection without side effects, the cap rejecting further generations while still allowing replay, per-outage scoping, and pruning restoring headroom. Documents the policy on calculate_sla, in the README FAQ, and in the audit-trail replay implications, where a successful response was previously implied to mean an event was emitted.

