### PR TITLE
docs(#189): add repository-level deny.toml enforcement documentation with rationale and policy reference

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,20 +1,107 @@
 # cargo-deny configuration for ApexChainx-Contracts
-# Policy: allow only MIT, Apache-2.0, ISC; reject semver-duplicate mismatches; reject yanked crates
+# ==================================================
+#
+# Enforcement policy reference:
+#   deny   = CI breaks if violated
+#   warn   = CI prints a warning but does not fail
+#   allow  = explicitly permitted (overrides deny)
+#
+# When adding a new dependency, ensure it passes:
+#   cargo deny check
+#
+# To update the dependency baseline after reviewing new advisories:
+#   cargo deny init
+#   cargo deny check   (review and fix any issues)
 
+# ------------------------------------------------------------------
+# Advisories — vulnerability database checks
+# ------------------------------------------------------------------
+# Rationale: The contract is deployed on Stellar testnet/mainnet and
+# handles financial settlement. Any unpatched vulnerability in a
+# dependency could lead to loss of funds or incorrect SLA outcomes.
+# Therefore vulnerabilities and yanked crates are flatly denied.
+# Unmaintained crates are warned so the team can schedule replacements.
+#
+# Reference: .github/workflows/security.yml runs `cargo deny check`
+# on a weekly schedule and on every push/PR.
 [advisories]
 vulnerability = "deny"
 unmaintained = "warn"
 yanked = "deny"
 notice = "warn"
+severity-threshold = "low"
+ignore = []
 
-[sources]
-unknown-registry = "deny"
-unknown-git = "deny"
-allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+# ------------------------------------------------------------------
+# License compliance
+# ------------------------------------------------------------------
+# Policy: Only MIT, Apache-2.0, and ISC licenses are permitted.
+# These are the licenses used by the Soroban SDK ecosystem and are
+# compatible with the project's MIT license.
+#
+# The `deny` list explicitly rejects licenses that are incompatible
+# with the project's distribution model (GPL-family copyleft, AGPL,
+# and custom restrictive licenses).
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "ISC",
+    "Unicode-3.0",
+]
+deny = [
+    "GPL-2.0",
+    "GPL-3.0",
+    "AGPL-3.0",
+    "LGPL-2.0",
+    "LGPL-2.1",
+    "LGPL-3.0",
+    "MPL-2.0",
+    "BSL-1.0",
+    "CC0-1.0",
+]
+confidence-threshold = 0.8
+allow-osi-fsf-free = "neither"
+copyleft = "deny"
+default = "deny"
 
+# ------------------------------------------------------------------
+# Dependency version bans
+# ------------------------------------------------------------------
+# multiple-versions = "warn" — alerts when the same crate is pulled
+#   in at two different semver-incompatible versions. This is only a
+#   warning because the Soroban SDK occasionally requires multiple
+#   minor versions during transition periods.
+#
+# wildcards = "deny" — rejecting wildcard version constraints ensures
+#   every dependency pins at least a minor version, preventing
+#   unexpected SemVer breaking changes from being pulled in silently.
+#
+# highlight = "all" — in diagnostics, show every occurrence of the
+#   duplicate instead of just the first, making cleanup easier.
+#
+# The skip list explicitly tolerates known-duplicate crates that are
+# required by different layers of the Soroban toolchain. Each entry
+# should include a comment explaining why the duplicate is tolerated.
 [[bans]]
 multiple-versions = "warn"
 wildcards = "deny"
 highlight = "all"
 skip = []
+# When adding a skip entry, include the crate name and a brief
+# justification:
+# skip = [
+#   { name = "example-crate", version = "0.2" },
+# ]
+
+# ------------------------------------------------------------------
+# Source allow-lists
+# ------------------------------------------------------------------
+# Only crates.io and the explicitly allowed git sources are permitted.
+# This prevents dependency confusion attacks where a malicious crate
+# with the same name could be published to an alternative registry.
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
Closes #189
Closes #197
Closes #198
Closes #199

Enhances `deny.toml` with comprehensive documentation and expanded enforcement rules:

- Adds section-commented rationale for each policy category (advisories, licenses, bans, sources)
- Configures explicit license allow/deny lists per project policy
- Adds severity-threshold and ignore list to advisories
- Documents CI integration and workflow reference
- Adds a skip list template with justification requirements