### PR TITLE
docs: add contract API archetypes note (#285)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,62 @@ contract and migrating state through the backend.
 
 This repository is the execution-layer side of the 3-repo architecture.
 
+## Contract API Archetypes
+
+Every public entrypoint in `apexchainx_calculator` belongs to one of three
+archetypes. Knowing which category a method falls into tells you immediately
+whether a call can be made freely, requires operator credentials, or is gated
+behind admin authority.
+
+### Read-only (no auth required, no state written)
+
+These functions can be called by anyone at any time — including while the
+contract is paused — and never modify on-chain state or emit events.
+
+| Group | Methods |
+|-------|---------|
+| Healthcheck & version | `healthcheck`, `get_version_info`, `get_migration_state` |
+| Pause / freeze status | `is_paused`, `get_pause_info`, `is_config_frozen` |
+| Config views | `get_config`, `get_config_snapshot`, `get_config_version_hash`, `list_configs`, `get_last_config_update`, `get_config_bundle` |
+| Custom severity views | `get_custom_severity`, `get_custom_config_snapshot` |
+| Stats & telemetry | `get_stats`, `get_economic_exposure`, `get_severity_telemetry` |
+| History views | `get_history`, `get_history_page`, `get_history_by_outage`, `get_latest_by_outage` |
+| Role queries | `get_admin`, `get_operator`, `get_pending_admin`, `get_pending_operator` |
+| Introspection | `get_result_schema`, `get_failure_schema`, `get_contract_metadata`, `get_full_audit_state` |
+| Retention helpers | `get_retention_limit`, `get_config_count`, `get_storage_version` |
+| View-mode calculation | `calculate_sla_view`, `replay_calculate_sla` |
+
+### Mutating — operator role
+
+These functions write state and emit events. Only the current **operator**
+address may call them.
+
+| Method | What it writes |
+|--------|----------------|
+| `calculate_sla` | Appends a result to history, updates cumulative stats and per-severity telemetry, emits `sla_calc` and `set_int` events. Idempotent on exact replay; rejects conflicting duplicates. |
+
+### Privileged — admin role
+
+These functions can only be called by the current **admin** address. They
+control the contract's lifecycle, configuration, and role management. Several
+of them are irreversible (e.g., `renounce_admin`) or have broad blast radius
+(e.g., `prune_history`), so treat them accordingly.
+
+| Group | Methods |
+|-------|---------|
+| Lifecycle | `initialize`, `migrate` |
+| Config management | `set_config`, `set_custom_severity`, `remove_custom_severity`, `freeze_config`, `unfreeze_config` |
+| Operational controls | `pause`, `unpause`, `set_retention_limit` |
+| Admin transfer | `propose_admin`, `accept_admin`, `cancel_admin_proposal`, `renounce_admin` |
+| Operator transfer | `set_operator` *(legacy direct)*, `propose_operator`, `accept_operator`, `cancel_operator_proposal` |
+| History pruning | `prune_history`, `prune_history_by_age` |
+
+> **Quick rule of thumb for contributors:** if the method name starts with
+> `get_`, `is_`, `list_`, `healthcheck`, `calculate_sla_view`, or
+> `replay_calculate_sla` it is read-only and safe to call freely. Everything
+> else either requires the operator role (`calculate_sla`) or the admin role
+> (everything remaining).
+
 ## Related Repositories
 
 | Repository | Description |

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -8,6 +8,7 @@
 - [Repository Architecture](#repository-architecture)
 - [System Flow](#system-flow)
 - [Architectural Rules](#architectural-rules)
+- [Contract API Archetypes](#contract-api-archetypes)
 - [SC-100: Future Contract Roadmap](#sc-100-future-contract-roadmap)
 
 ---
@@ -39,6 +40,62 @@ The ApexChainx platform is composed of three repositories:
 1. **Frontend never calls contracts directly** — all contract interactions go through the backend
 2. **Backend is the exclusive bridge** — translates contract data to frontend-friendly responses
 3. **Contracts are execution-layer only** — pure deterministic computation, no external dependencies
+
+---
+
+## Contract API Archetypes
+
+Every public entrypoint in `apexchainx_calculator` falls into one of three
+archetypes. This classification is the fastest way for contributors and
+integrators to decide whether a call is safe to make freely, requires the
+operator role, or is gated behind admin authority.
+
+### Read-only (no auth required, no state written)
+
+Safe to call by anyone at any time, including while the contract is paused.
+No on-chain state is written and no events are emitted.
+
+| Group | Methods |
+|-------|---------|
+| Healthcheck & version | `healthcheck`, `get_version_info`, `get_migration_state` |
+| Pause / freeze status | `is_paused`, `get_pause_info`, `is_config_frozen` |
+| Config views | `get_config`, `get_config_snapshot`, `get_config_version_hash`, `list_configs`, `get_last_config_update`, `get_config_bundle` |
+| Custom severity views | `get_custom_severity`, `get_custom_config_snapshot` |
+| Stats & telemetry | `get_stats`, `get_economic_exposure`, `get_severity_telemetry` |
+| History views | `get_history`, `get_history_page`, `get_history_by_outage`, `get_latest_by_outage` |
+| Role queries | `get_admin`, `get_operator`, `get_pending_admin`, `get_pending_operator` |
+| Introspection | `get_result_schema`, `get_failure_schema`, `get_contract_metadata`, `get_full_audit_state` |
+| Retention helpers | `get_retention_limit`, `get_config_count`, `get_storage_version` |
+| View-mode calculation | `calculate_sla_view`, `replay_calculate_sla` |
+
+### Mutating — operator role
+
+Writes state and emits events. Only the current **operator** address may call
+these.
+
+| Method | What it writes |
+|--------|----------------|
+| `calculate_sla` | Appends a result to history, updates cumulative stats and per-severity telemetry, emits `sla_calc` and `set_int` events. Idempotent on exact replay; rejects conflicting duplicates. |
+
+### Privileged — admin role
+
+Only the current **admin** address may call these. They control lifecycle,
+configuration, and role management. Some are irreversible (`renounce_admin`)
+or have broad blast radius (`prune_history`).
+
+| Group | Methods |
+|-------|---------|
+| Lifecycle | `initialize`, `migrate` |
+| Config management | `set_config`, `set_custom_severity`, `remove_custom_severity`, `freeze_config`, `unfreeze_config` |
+| Operational controls | `pause`, `unpause`, `set_retention_limit` |
+| Admin transfer | `propose_admin`, `accept_admin`, `cancel_admin_proposal`, `renounce_admin` |
+| Operator transfer | `set_operator` *(legacy direct)*, `propose_operator`, `accept_operator`, `cancel_operator_proposal` |
+| History pruning | `prune_history`, `prune_history_by_age` |
+
+> **Quick rule of thumb:** methods whose names start with `get_`, `is_`,
+> `list_`, `healthcheck`, `calculate_sla_view`, or `replay_calculate_sla` are
+> read-only and safe to call freely. `calculate_sla` requires the operator
+> role. Everything else requires the admin role.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #285

Adds a concise **Contract API Archetypes** note to help contributors
immediately recognise whether a public entrypoint is read-only, mutating,
or admin-only — without having to read through the full source.

## Changes

| File | Change |
|------|--------|
`README.md` | New *Contract API Archetypes* section between the FAQ and the Related Repositories table |
`docs/PROJECT_CONTEXT.md` | Same section (with TOC entry) before the SC-100 roadmap block |

No Rust source files were modified.

## Acceptance criteria

- [x] Archetype note exists in both files
- [x] Separates public reads, mutating operations, and admin-only actions
- [x] Scannable method tables with a quick rule-of-thumb callout

## Testing

CI lint, build, and test steps are entirely unaffected — only Markdown
files were changed. The no-std lint script scans `*.rs` files only.