### PR TITLE
docs: add SLAError addition contributor guide and fix missing predica…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ## [Unreleased]
 
 ### Added
+- **[SC-509] SLAError Addition Workflow** (#253) — comprehensive contributor guide for adding, deprecating, or reviewing `SLAError` variants without breaking backend adapter logic. See `docs/sla-error-additions-guide.md`.
+- `error_responses::is_severity_not_in_set` — typed helper predicate for `SLAError::SeverityNotInSet` (#253)
+- `docs/sla-error-additions-guide.md` — step-by-step guide covering SLAError enum management, the typed helper layer, compatibility expectations, and testing requirements (#253)
 - `docs/CONTRACT_MAINTENANCE_POLICY.md` — comprehensive maintenance policy covering `#[contracttype]` compatibility notes (#279), response-shape stability (#283), version negotiation (#284), API archetypes (#285), event payload size checks (#286), event drift review (#287), history write audit (#288), telemetry counters (#289), and role-change incident review (#290)
 - `tooling/release-summary.ts` — release summary generator for maintainers (#280)
 - `.devcontainer/` — reproducible dev container workspace with Rust + WASM target + just + Node.js (#281)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ expertise help make this project better for everyone in the Stellar ecosystem.
 - [Testing Guidelines](#testing-guidelines)
 - [Documentation Guidelines](#documentation-guidelines)
 - [Security Guidelines](#security-guidelines)
+- [SLAError Addition Workflow](#slaerror-addition-workflow)
 - [Reporting Bugs](#reporting-bugs)
 - [Suggesting Features](#suggesting-features)
 - [Getting Help](#getting-help)
@@ -455,6 +456,34 @@ pytest --cov=app --cov-report=html
 - ❌ Never trust user input without validation
 - ❌ Never use unsafe code in smart contracts
 
+---
+
+## SLAError Addition Workflow
+
+Adding a new `SLAError` variant is a **contract interface change**, even when it
+appears to be an internal detail.  Backend consumers that depend on numeric error
+discriminants or call `get_failure_schema()` to build a lookup table must be able
+to adapt without silent failures.
+
+**Full guide:** [`docs/sla-error-additions-guide.md`](docs/sla-error-additions-guide.md)
+
+### Quick rules
+
+| Rule | Detail |
+|------|--------|
+| Append only | New variants go at the **end** of `SLAError`, never in the middle |
+| Stable discriminants | Once shipped, `FooError = N` means `N` maps to `FooError` forever — never renumber or remove |
+| Typed helper required | Every new variant needs a matching `is_<variant>` predicate in `error_responses.rs` |
+| Catalogue update required | `get_failure_schema()` must include an entry for every variant |
+| CHANGELOG required | Add an entry under `[Unreleased]` noting the new variant and discriminant |
+| Tests required | Unit test for the error path + predicate smoke test + catalogue count assertion |
+| Backend notification | If any existing label or discriminant changes, notify the `apexchainx-be` team |
+
+See the [full guide](docs/sla-error-additions-guide.md) for step-by-step
+instructions, deprecation protocol, and compatibility guarantees.
+
+---
+
 ## 🐛 Reporting Bugs
 
 | Field | Description | Required |
@@ -520,6 +549,9 @@ This covers:
   saturation handling.
 - **[SC-508] Role-Change Incident Review Note** (#290) — admin/operator handoff
   safety decision table.
+- **[SC-509] SLAError Addition Workflow** (#253) — step-by-step guide for adding,
+  deprecating, or reviewing `SLAError` variants without breaking backend adapter
+  logic. See [`docs/sla-error-additions-guide.md`](docs/sla-error-additions-guide.md).
 
 ### Release Summary Generator (#280)
 

--- a/apexchainx_calculator/src/error_responses.rs
+++ b/apexchainx_calculator/src/error_responses.rs
@@ -68,6 +68,10 @@ pub fn is_invalid_input(err: &SLAError) -> bool {
     matches!(err, SLAError::InvalidInput)
 }
 
+pub fn is_severity_not_in_set(err: &SLAError) -> bool {
+    matches!(err, SLAError::SeverityNotInSet)
+}
+
 pub fn is_outage_recalc_limit(err: &SLAError) -> bool {
     matches!(err, SLAError::OutageRecalcLimit)
 }

--- a/docs/sla-error-additions-guide.md
+++ b/docs/sla-error-additions-guide.md
@@ -1,0 +1,340 @@
+# SLAError Addition Guide
+
+> **Contributor guide for introducing new error categories in `SLAError`.**
+>
+> This document covers the complete workflow for adding, deprecating, or
+> reorganising error codes in `apexchainx_calculator/src/lib.rs` and the
+> companion typed-helper layer in `apexchainx_calculator/src/error_responses.rs`.
+>
+> A new error code is a **contract interface change**, even when it looks like
+> an internal detail.  Backend consumers that rely on the numeric discriminant
+> or the `get_failure_schema()` catalogue must be able to adapt without silent
+> data corruption or panics.  Follow this guide in full before opening a PR.
+
+---
+
+## Table of Contents
+
+1. [Why error-code additions are interface changes](#why-error-code-additions-are-interface-changes)
+2. [The SLAError enum and its discriminants](#the-slaerror-enum-and-its-discriminants)
+3. [The typed helper layer (`error_responses.rs`)](#the-typed-helper-layer-error_responsesrs)
+4. [Step-by-step: adding a new error category](#step-by-step-adding-a-new-error-category)
+5. [Step-by-step: deprecating an error category](#step-by-step-deprecating-an-error-category)
+6. [Compatibility expectations for backend consumers](#compatibility-expectations-for-backend-consumers)
+7. [Testing requirements](#testing-requirements)
+8. [Checklist before opening a PR](#checklist-before-opening-a-pr)
+9. [Reference: current error catalogue](#reference-current-error-catalogue)
+
+---
+
+## Why error-code additions are interface changes
+
+The `SLAError` enum is compiled into the contract's WASM binary and serialised
+on-chain as a `u32` discriminant whenever a call fails.  Backend consumers
+(the `apexchainx-be` bridge and any downstream indexers) receive this
+discriminant and map it to a human-readable label via `get_failure_schema()`.
+
+A change to the enum affects consumers in the following ways:
+
+| Change type | Consumer impact |
+|---|---|
+| **Append a new variant** | Consumers that call `get_failure_schema()` see a new entry. Old consumers that do not recognise the code surface "unknown error"; they do **not** misinterpret an existing code. Safe, but must be communicated. |
+| **Remove or renumber an existing variant** | Any consumer that hard-codes the numeric code or calls `get_failure_schema()` to build a lookup table will silently misidentify errors. **Breaking — never do this.** |
+| **Rename a variant (same discriminant)** | The numeric wire format is unchanged. The `get_failure_schema()` label changes. Consumers using the label as a stable key are broken. Treat as **breaking** — coordinate with the `apexchainx-be` team. |
+| **Change a variant's `#[doc]` comment only** | No wire format impact. Safe. |
+
+---
+
+## The SLAError enum and its discriminants
+
+`SLAError` lives in `apexchainx_calculator/src/lib.rs` and is annotated with
+`#[contracterror]` and `#[repr(u32)]`:
+
+```rust
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum SLAError {
+    AlreadyInitialized    = 1,
+    NotInitialized        = 2,
+    Unauthorized          = 3,
+    // … (see reference catalogue below)
+    OutageRecalcLimit     = 19,
+}
+```
+
+**Rules that must never be violated:**
+
+1. Discriminant values are permanent. Once `FooError = 7` ships in a released
+   binary, `7` is reserved for `FooError` for the lifetime of the contract.
+2. New variants must use the **next available integer** (currently `20` for the
+   first new addition after the existing 19).  Do not use gaps or reorder.
+3. Every variant needs a `/// <description>` doc comment that explains the
+   error condition precisely enough that a backend engineer can write a recovery
+   path without reading the contract source.
+
+---
+
+## The typed helper layer (`error_responses.rs`)
+
+`apexchainx_calculator/src/error_responses.rs` exposes a `is_<variant_name>`
+predicate for every variant in `SLAError`.  Backend consumers and integration
+tests use these predicates instead of matching on raw discriminants, so a
+rename only requires updating the predicate — not every call site.
+
+Example (existing):
+
+```rust
+pub fn is_outage_recalc_limit(err: &SLAError) -> bool {
+    matches!(err, SLAError::OutageRecalcLimit)
+}
+```
+
+**Every new variant in `SLAError` must have a matching predicate added to
+`error_responses.rs` in the same PR.**
+
+The predicate naming convention is `is_<snake_case_variant_name>`.
+
+---
+
+## Step-by-step: adding a new error category
+
+### 1. Confirm the error is not already covered
+
+Search the existing catalogue (see [Reference](#reference-current-error-catalogue))
+and `get_failure_schema()` in `lib.rs`.  A new variant is only warranted if no
+existing code describes the failure precisely enough.
+
+### 2. Choose the next discriminant
+
+Inspect the current highest discriminant in `SLAError`.  As of this writing it
+is `OutageRecalcLimit = 19`.  Assign `20` to the first new variant, `21` to the
+second, and so on.
+
+### 3. Add the variant to `SLAError` in `lib.rs`
+
+Append at the **end** of the enum:
+
+```rust
+/// <One-sentence summary of the condition that triggers this error.>
+///
+/// # Semantics
+///
+/// <Explain when exactly this error is returned.  Include a decision table
+/// if the condition depends on multiple input states.>
+///
+/// # Consumer guidance
+///
+/// <What should a backend caller do when it receives this error?
+/// E.g. "Retry with corrected input", "Alert admin", "Surface to user".>
+MyNewError = 20,
+```
+
+> **Do not** insert the variant in the middle of the enum — append only.
+
+### 4. Add the predicate to `error_responses.rs`
+
+```rust
+pub fn is_my_new_error(err: &SLAError) -> bool {
+    matches!(err, SLAError::MyNewError)
+}
+```
+
+### 5. Update `get_failure_schema()` in `lib.rs`
+
+Extend the `entries` array in `get_failure_schema()`.  The array is in
+ascending numeric order; append the new entry at the end:
+
+```rust
+let entries: [(u32, &str, &str); 20] = [
+    // … existing 19 entries …
+    (20, "MyNewError", "Short description ≤ 32 chars"),
+];
+```
+
+Both the label (`&str` for `Symbol::new`) and the description must be **≤ 32
+bytes** to satisfy the Soroban `Symbol` size constraint.  Use abbreviated
+wording if needed (e.g. `"Calr lacks req role"` instead of
+`"Caller lacks required role"`).
+
+Also update the array length literal in the type annotation from `; 19]` to
+`; 20]` (or whatever the new count is).
+
+### 6. Emit the new error at the appropriate contract site
+
+Return `Err(SLAError::MyNewError)` at every point in the contract logic where
+this failure condition is detected.  Include a comment referencing the issue
+that motivated the new error.
+
+### 7. Update `CHANGELOG.md`
+
+Under `[Unreleased]` → `Changed`:
+
+```markdown
+- `SLAError` — added `MyNewError = 20` (short description of condition)
+  (closes #NNN)
+```
+
+If this is the first `SLAError` change in the release, open a new sub-heading:
+
+```markdown
+### Changed
+- `SLAError` — added `MyNewError = 20` …
+```
+
+### 8. Write or update tests
+
+See [Testing requirements](#testing-requirements).
+
+### 9. Run the full CI pipeline locally
+
+```bash
+cd apexchainx_calculator
+cargo fmt
+cargo clippy -- -D warnings
+cargo test --lib
+cargo check --target wasm32-unknown-unknown --lib
+```
+
+All four commands must exit 0 before pushing.
+
+---
+
+## Step-by-step: deprecating an error category
+
+Error codes are **never removed**.  If a variant becomes unreachable due to a
+refactor, mark it as deprecated in a doc comment but leave the discriminant
+in place:
+
+```rust
+/// **Deprecated** — no longer returned as of schema version N.
+/// Kept for wire-format stability; backend consumers may ignore this code.
+/// Replacement: `SLAError::MyNewError = 20`.
+OldError = 7,
+```
+
+Update the `description` in `get_failure_schema()` to include `"[deprecated]"`
+so callers that load the schema at runtime are informed:
+
+```rust
+(7, "OldError", "[deprecated] Use MyNewError"),
+```
+
+Document the deprecation in `CHANGELOG.md` under `Changed`.
+
+---
+
+## Compatibility expectations for backend consumers
+
+| Guarantee | Detail |
+|---|---|
+| **Numeric stability** | Once shipped, `SLAError::Foo = N` means `N` maps to `Foo` forever. The backend may cache this mapping indefinitely. |
+| **Additive additions are non-breaking** | A new variant appended at the end does not invalidate any existing mapping. The backend should treat an unrecognised code as `"unknown_error"` and surface it as a warning, not a crash. |
+| **Label stability** | `get_failure_schema()` label strings are considered stable once a version is released. Changing a label is a **breaking change** that requires coordination with the `apexchainx-be` team and a version bump in the schema's `version` field. |
+| **At least one release cycle notice** | If a change touches existing variant names or discriminants, the `apexchainx-be` team must be notified at least one release cycle in advance so they can deploy an adapter before the breaking binary reaches the network. |
+
+---
+
+## Testing requirements
+
+Every PR that modifies `SLAError` or `error_responses.rs` must include:
+
+### Unit test for the new error path
+
+Write a test in `apexchainx_calculator/src/tests.rs` (or a dedicated test
+module) that triggers the exact contract function that returns the new error and
+asserts the correct discriminant:
+
+```rust
+#[test]
+fn test_my_new_error_returned_on_condition_x() {
+    // … set up env, initialize contract …
+    let result = SLACalculatorContract::some_function(env, …);
+    assert!(result.is_err());
+    assert!(error_responses::is_my_new_error(&result.unwrap_err()));
+}
+```
+
+### Predicate smoke test
+
+Add a quick smoke test for the new predicate in `error_responses.rs` alongside
+the existing tests (or create `tests/error_responses_tests.rs`):
+
+```rust
+#[test]
+fn test_is_my_new_error_predicate() {
+    assert!(error_responses::is_my_new_error(&SLAError::MyNewError));
+    assert!(!error_responses::is_my_new_error(&SLAError::Unauthorized));
+}
+```
+
+### `get_failure_schema()` catalogue coverage test
+
+Verify that `get_failure_schema()` returns exactly the expected number of
+entries and that each new entry is present.  A test template:
+
+```rust
+#[test]
+fn test_failure_schema_includes_new_error() {
+    let env = Env::default();
+    // … initialize contract …
+    let schema = SLACalculatorContract::get_failure_schema(env).unwrap();
+    // Update the expected count to match the new total
+    assert_eq!(schema.codes.len(), 20);
+    let my_code = schema.codes.iter().find(|c| c.code == 20);
+    assert!(my_code.is_some());
+}
+```
+
+---
+
+## Checklist before opening a PR
+
+Use this checklist for every PR that adds, renames, or deprecates an `SLAError`
+variant:
+
+- [ ] New variant is appended at the end of the enum — not inserted in the middle
+- [ ] Discriminant is the next available integer (no gaps)
+- [ ] Variant has a `///` doc comment with at least: a one-line summary, a
+      semantics section, and a consumer guidance section
+- [ ] Matching `is_<variant>` predicate added to `error_responses.rs`
+- [ ] `get_failure_schema()` updated: new entry added to `entries` array and
+      array length constant incremented
+- [ ] New error is returned at the correct contract site(s)
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`
+- [ ] Unit test for the contract path that returns the new error
+- [ ] Predicate smoke test
+- [ ] `get_failure_schema()` catalogue coverage test
+- [ ] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo test --lib`, and
+      `cargo check --target wasm32-unknown-unknown --lib` all pass
+- [ ] `apexchainx-be` team notified if any existing label or discriminant changed
+
+---
+
+## Reference: current error catalogue
+
+| Discriminant | Variant | Short description |
+|---:|---|---|
+| 1 | `AlreadyInitialized` | Contract already initialized |
+| 2 | `NotInitialized` | Contract not yet initialized |
+| 3 | `Unauthorized` | Caller lacks required role |
+| 4 | `ConfigNotFound` | No config for severity |
+| 5 | `VersionMismatch` | Storage version mismatch |
+| 6 | `ContractPaused` | Contract is paused |
+| 7 | `NoPendingTransfer` | No pending transfer |
+| 8 | `InvalidThreshold` | Threshold out of range |
+| 9 | `InvalidPenalty` | Penalty out of range |
+| 10 | `InvalidReward` | Reward out of range |
+| 11 | `InvalidSeverity` | Severity not supported |
+| 12 | `RetentionLimitOutOfRange` | Retention limit out of range |
+| 13 | `DuplicateOutageInput` | Conflicting duplicate outage_id |
+| 14 | `InvalidPenaltyAmount` | Invalid penalty amount |
+| 15 | `InvalidRewardAmount` | Invalid reward amount |
+| 16 | `ConfigFrozen` | Configuration is frozen |
+| 17 | `InvalidInput` | Invalid input parameter |
+| 18 | `SeverityNotInSet` | Custom severity not registered |
+| 19 | `OutageRecalcLimit` | Outage recalc limit reached |
+| **20+** | *(next available)* | *(reserved for future additions)* |
+
+> This table is auto-derived from `get_failure_schema()` in `lib.rs`.  Keep
+> both in sync whenever the catalogue changes.


### PR DESCRIPTION
…te (#253)

- Add docs/sla-error-additions-guide.md: step-by-step guide for adding, deprecating, and reviewing SLAError variants. Covers enum discriminant stability rules, the typed helper layer, compatibility expectations for backend consumers, testing requirements, and a pre-PR checklist.

- Add error_responses::is_severity_not_in_set predicate which was missing despite SLAError::SeverityNotInSet = 18 being defined in the enum.

- Update CONTRIBUTING.md:
  - Add 'SLAError Addition Workflow' to the Table of Contents
  - Add [SC-509] entry in Contract Maintenance Policies
  - Add dedicated 'SLAError Addition Workflow' section with quick-rules table and link to the full guide

- Update CHANGELOG.md under [Unreleased] to record SC-509 additions.

Closes #253

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issues
Fixes #(issue number) or relates to #(issue number)

## Changes Made
- 
- 
- 

## Testing
Describe the testing performed to validate these changes:
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented complex logic
- [ ] I have updated relevant documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes do not introduce new warnings

## Screenshots (if applicable)
Add screenshots or logs if applicable.


closes #253 
