### PR TITLE
docs: add maintainership notes for cargo udeps and dependency hygiene (#278)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ expertise help make this project better for everyone in the Stellar ecosystem.
 - [Code Style Guidelines](#code-style-guidelines)
 - [Pull Request Guidelines](#pull-request-guidelines)
 - [Testing Guidelines](#testing-guidelines)
+- [Dependency Hygiene](#-dependency-hygiene)
 - [Documentation Guidelines](#documentation-guidelines)
 - [Security Guidelines](#security-guidelines)
 - [Reporting Bugs](#reporting-bugs)
@@ -350,6 +351,8 @@ impl SLAContract {
 - [ ] `cargo test` passes
 - [ ] `cargo clippy -- -D warnings` produces no warnings
 - [ ] `cargo fmt -- --check` confirms formatting compliance
+- [ ] `cargo machete` passes (no unused dependencies in `Cargo.toml`)
+- [ ] `cargo +nightly udeps --all-targets` passes (no unused dependencies in code; requires nightly toolchain)
 - [ ] `cargo check --target wasm32-unknown-unknown --lib` passes (no-std check)
 - [ ] New public functions are added to the result schema or documented
 - [ ] Any breaking change to `SLAResult` increments `RESULT_SCHEMA_VERSION`
@@ -427,6 +430,62 @@ pytest
 pytest tests/test_payment_service.py
 pytest --cov=app --cov-report=html
 ```
+
+## 🧹 Dependency Hygiene
+
+The CI pipeline checks for unused dependencies to keep the codebase lean and
+maintainable. Drift from unused dependencies silently increases build times,
+attack surface, and maintenance burden.
+
+### Why It Matters
+
+- **`cargo machete`** detects dependencies declared in `Cargo.toml` that are no
+  longer imported anywhere in the crate. Removing them reduces compile time and
+  audit surface.
+- **`cargo udeps`** detects dependencies that are available in the workspace but
+  not actually used by the crate's code. This catches cases where a dependency
+  was added for an experiment and never cleaned up.
+
+Both checks are enforced in CI (see the **Unused dependency gate** step in
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml)). A PR that introduces
+unused dependencies will fail CI.
+
+### How to Run Locally
+
+```bash
+# Install the tools (one-time)
+cargo install cargo-machete --locked
+cargo install cargo-udeps --locked
+
+# Ensure the nightly toolchain is available (required by cargo-udeps)
+rustup toolchain install nightly
+
+# Check for unused dependencies
+cd apexchainx_calculator
+cargo machete
+cargo +nightly udeps --all-targets
+```
+
+Or use the `just` recipes (see [`justfile`](justfile)):
+
+```bash
+just machete
+just udeps
+```
+
+The full CI pipeline — including both hygiene checks — can be run with:
+
+```bash
+just ci
+```
+
+> **Tip:** Run `just machete` and `just udeps` before opening a PR to catch
+> dependency issues early. The [PR checklist](#before-submitting-checklist)
+> includes both checks under the *Smart Contract Specific* section.
+>
+> **Note:** `cargo-udeps` uses nightly-only compiler features, so it requires
+> the nightly Rust toolchain. The `just udeps` recipe handles this automatically
+> by invoking `cargo +nightly udeps`.
 
 ## 📚 Documentation Guidelines
 

--- a/README.md
+++ b/README.md
@@ -96,5 +96,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed setup instructions.
 - **[Release Artifact Provenance Policy](docs/RELEASE_PROVENANCE_POLICY.md)** — Guidelines for WASM output checksums and snapshot check-ins.
 - **[Release Summary Format](docs/RELEASE_SUMMARY_FORMAT.md)** — Structured ship-review note format for maintainer release triage. Generate one with `just release-summary` (or `just release-summary <version>`).
 - **Dependency auditing:** `cargo audit` runs on CI for every push
+- **Dependency hygiene:** `cargo machete` and `cargo udeps` prevent unused dependency drift — see [Dependency Hygiene in CONTRIBUTING.md](CONTRIBUTING.md#-dependency-hygiene) for details.
 - **WASM integrity:** Release artifacts include SHA-256 manifests
 - **Reproducible builds:** Local builds can be verified against CI-generated manifests

--- a/justfile
+++ b/justfile
@@ -90,6 +90,17 @@ hash: wasm-release
         shasum -a 256 "$wasm" | awk '{print $1 "  {{crate}}.wasm"}'
     fi
 
+# ------------------------------------------------------- dependency-hygiene -----
+
+# Check for unused dependencies with cargo-machete.              [CI: Unused dependency gate]
+machete:
+    cargo install cargo-machete --locked 2>/dev/null; cd {{crate}} && cargo machete
+
+# Check for unused dependencies with cargo-udeps.                [CI: Unused dependency gate]
+# Requires nightly Rust — install with: rustup toolchain install nightly
+udeps:
+    cargo install cargo-udeps --locked 2>/dev/null; cd {{crate}} && cargo +nightly udeps --all-targets
+
 # --------------------------------------------------------------- tooling -----
 
 # Generate a ship-review note from CHANGELOG.md.
@@ -105,5 +116,5 @@ clean:
     cd {{crate}} && cargo clean
 
 # Everything CI gates on, in CI's order. Run before opening a PR.
-ci: fmt-check lint check no-std test fuzz wasm
+ci: fmt-check lint check no-std machete udeps test fuzz wasm
     @echo "✓ local CI equivalent passed"


### PR DESCRIPTION
## Overview

This PR documents the purpose of `cargo machete` and `cargo udeps` dependency hygiene checks and explains how contributors can run them locally.

## Related Issue

Closes #278

## Changes

### 📖 Documentation

- **[ADD]** New **Dependency Hygiene** section in `CONTRIBUTING.md` explaining:
  - Why `cargo machete` and `cargo udeps` matter (build times, attack surface, maintenance burden)
  - How to install and run both tools locally
  - That `cargo udeps` requires the nightly Rust toolchain
  - Added both checks to the Smart Contract Specific PR checklist
  - Added section to the Table of Contents

- **[ADD]** `just machete` and `just udeps` recipes in `justfile` mirroring the CI's "Unused dependency gate" step
- **[MODIFY]** `just ci` now includes both `machete` and `udeps`
- **[MODIFY]** `README.md` — added **Dependency hygiene** bullet under "Security & Supply Chain" with link to CONTRIBUTING.md

## Verification Results

- ✅ `cargo machete` installed and runs successfully — no unused dependencies found
- ✅ `cargo udeps` recognized as requiring nightly toolchain (documented accordingly)
- ✅ `just` recipes mirror CI step exactly

| Acceptance Criteria | Status |
| --- | --- |
| Contributor docs explain purpose of the checks | ✅ |
| Local command/script to reproduce them | ✅ (raw cargo + just recipes) |
| Docs linked from repository guidance | ✅ (README, PR checklist, ToC) |