### PR TITLE
test: expand storage key namespace regression to cover all 17 keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ## [Unreleased]
 
+### Changed
+- `test_storage_key_namespace_symbols_are_distinct` now covers all 17 on-chain storage key constants (previously omitted `SEVERITY_CALC_COUNTS_KEY`, `SEVERITY_VIOL_COUNTS_KEY`, `LAST_CALCULATION_LEDGER_KEY`, `LAST_VIOLATION_LEDGER_KEY`, and `LAST_CFG_UPDATE_KEY`). The assertion now includes the colliding indices in its error message for faster diagnosis. A maintenance comment listing every key and a pointer to this test was added to both the storage-key block in `lib.rs` and the test itself so future contributors know to update both locations when adding a new key.
+
 ### Added
 - `docs/CONTRACT_MAINTENANCE_POLICY.md` — comprehensive maintenance policy covering `#[contracttype]` compatibility notes (#279), response-shape stability (#283), version negotiation (#284), API archetypes (#285), event payload size checks (#286), event drift review (#287), history write audit (#288), telemetry counters (#289), and role-change incident review (#290)
 - `tooling/release-summary.ts` — release summary generator for maintainers (#280)

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -45,6 +45,13 @@ use crate::config_bundle::ConfigBundle;
 //   - Within the 9-character Symbol limit for Soroban
 //
 // References: Issue numbers track the original feature requirements.
+//
+// MAINTENANCE: When you add a new storage key constant here (or re-export
+// one via `pub use`), you MUST also add it to the collision regression test:
+//   apexchainx_calculator/src/tests.rs
+//   → test_storage_key_namespace_symbols_are_distinct
+// That test is the sole enforcement mechanism for namespace uniqueness.
+// A missing entry is a silent aliasing bug waiting to happen.
 
 /// Admin address — set during initialize, governs config and roles.
 pub(crate) const ADMIN_KEY: Symbol = symbol_short!("ADMIN");

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -281,6 +281,39 @@ fn test_stranger_cannot_set_config() {
 
 #[test]
 fn test_storage_key_namespace_symbols_are_distinct() {
+    // -----------------------------------------------------------------------
+    // Storage-key collision regression test.
+    //
+    // Guards against future contributors accidentally reusing a Symbol string
+    // that is already occupied by another on-chain key.  Soroban instance
+    // storage is a flat key-value namespace: two constants that resolve to the
+    // same Symbol will silently alias the same storage slot, corrupting state.
+    //
+    // HOW TO MAINTAIN:
+    //   Every on-chain storage key constant defined in lib.rs (or re-exported
+    //   into it via `pub use`) MUST appear in this array.  When you add a new
+    //   key constant, append it here and run `cargo test --lib` to confirm
+    //   there is no collision before merging.
+    //
+    // KEY DEFINITIONS (all in apexchainx_calculator/src/lib.rs):
+    //   ADMIN_KEY                  = "ADMIN"
+    //   OPERATOR_KEY               = "OPERATOR"
+    //   PENDING_ADMIN_KEY          = "PADMIN"
+    //   PENDING_OP_KEY             = "POP"
+    //   CONFIG_KEY                 = "CONFIG"
+    //   CUSTOM_CONFIG_KEY          = "CUSTCFG"
+    //   PAUSED_KEY                 = "PAUSED"
+    //   PAUSE_INFO_KEY             = "PAUSEINF"
+    //   STATS_KEY                  = "STATS"
+    //   SEVERITY_CALC_COUNTS_KEY   = "CALCCNT"
+    //   SEVERITY_VIOL_COUNTS_KEY   = "VIOLCNT"
+    //   LAST_CALCULATION_LEDGER_KEY= "CALCLDG"
+    //   LAST_VIOLATION_LEDGER_KEY  = "VIOLLDG"
+    //   HISTORY_KEY                = "HIST"
+    //   STORAGE_VERSION_KEY        = "VER"
+    //   RETENTION_LIMIT_KEY        = "RETLIM"
+    //   LAST_CFG_UPDATE_KEY        = "LCFGUPD"  (re-exported from config_metadata)
+    // -----------------------------------------------------------------------
     let keys = [
         ADMIN_KEY,
         OPERATOR_KEY,
@@ -291,14 +324,23 @@ fn test_storage_key_namespace_symbols_are_distinct() {
         PAUSED_KEY,
         PAUSE_INFO_KEY,
         STATS_KEY,
+        SEVERITY_CALC_COUNTS_KEY,
+        SEVERITY_VIOL_COUNTS_KEY,
+        LAST_CALCULATION_LEDGER_KEY,
+        LAST_VIOLATION_LEDGER_KEY,
         HISTORY_KEY,
         STORAGE_VERSION_KEY,
         RETENTION_LIMIT_KEY,
+        LAST_CFG_UPDATE_KEY,
     ];
 
     for i in 0..keys.len() {
         for j in (i + 1)..keys.len() {
-            assert_ne!(keys[i], keys[j]);
+            assert_ne!(
+                keys[i], keys[j],
+                "storage key collision: keys[{}] == keys[{}] (both resolve to the same Symbol)",
+                i, j
+            );
         }
     }
 }


### PR DESCRIPTION
  Expand storage key namespace regression test to cover all 17 on-chain keys

  Summary

  test_storage_key_namespace_symbols_are_distinct is the sole enforcement mechanism preventing
  silent storage key collisions in the contract. It was checking 12 of the 17 defined on-chain
  storage key constants, leaving five keys unguarded:
  
  ┌──────────────────────────┬───────────────┐
  │ Missing constant         │ Symbol string │
  ├──────────────────────────┼───────────────┤
  │ SEVERITY_CALC_COUNTS_KEY │ "CALCCNT"     │
  ├─────────────────────────────┼───────────────┤
  │ SEVERITY_VIOL_COUNTS_KEY    │ "VIOLCNT"     │
  ├─────────────────────────────┼───────────────┤
  │ LAST_CALCULATION_LEDGER_KEY │ "CALCLDG"     │
  ├─────────────────────────────┼───────────────┤
  │ LAST_VIOLATION_LEDGER_KEY   │ "VIOLLDG"     │
  ├─────────────────────────────┼───────────────┤
  │ LAST_CFG_UPDATE_KEY         │ "LCFGUPD"     │
  └─────────────────────────────┴───────────────┘
  
  Why it matters
  
  Soroban instance storage is a flat key-value namespace. Two Symbol constants that resolve to
  the same string silently alias the same storage slot — the bug is invisible at compile time and
  produces corrupted state at runtime with no error or panic. The four telemetry keys in
  particular are packed into a single u128 via a lane scheme; a collision there would silently
  corrupt the wrong lane on every calculation.
  
  Changes
  
  - src/tests.rs — Added all 5 missing keys to the regression test array (12 → 17 total).
  Upgraded the assert_ne! call to include the colliding indices in its failure message for faster
  diagnosis. Added a HOW TO MAINTAIN comment block listing all 17 keys with their symbol_short!
  strings.
  - src/lib.rs — Added a MAINTENANCE note to the Storage Keys block comment pointing to this test
  as the sole enforcement mechanism and explaining the aliasing risk.
  - CHANGELOG.md — Added an [Unreleased] entry describing the fix.
  
  Testing
  
  cargo test --lib — 492 passed, 0 failed. test_storage_key_namespace_symbols_are_distinct passes
  with all 17 keys exercised.
  
  Checklist
  
  - No new dependencies
  - No storage layout changes
  - No event schema changes
  - No API surface changes
  - no_std / WASM conventions preserved

closes #222 