### PR TITLE
feat: resolve issues #287 #281 #270 — event drift checklist, devcontainer setup, release replay command

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,64 @@
+# Devcontainer Setup
+
+> Reproducible development environment for ApexChainx smart contracts.
+> Works with GitHub Codespaces and VS Code Dev Containers.
+
+## What's Included
+
+| Tool | Purpose |
+|------|---------|
+| Rust (latest) | Contract compilation and testing |
+| `wasm32-unknown-unknown` target | Soroban WASM builds |
+| `just` command runner | One-command dev workflows |
+| Node.js LTS | TypeScript tooling scripts |
+| `cargo clippy` | Linting on save |
+| `rust-analyzer` | IDE support |
+
+## Getting Started
+
+### GitHub Codespaces
+
+1. Click **Code** → **Codespaces** → **Create codespace on main**
+2. Wait for the environment to build (~3–5 minutes first time)
+3. The post-create script runs `just bootstrap` automatically
+4. Run `just ci` to verify everything works
+
+### VS Code (Local)
+
+1. Install [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+2. Open the repo folder in VS Code
+3. Click **Reopen in Container** when prompted
+4. Run `just ci` to verify
+
+## Daily Workflow
+
+```bash
+# Before committing
+just fmt              # Auto-format code
+just lint             # Run clippy
+just check            # Type-check
+
+# Before opening a PR
+just ci               # Full CI pipeline locally
+
+# Fast release validation
+just release-replay   # Minimal validation (fast)
+
+# Generate a release summary
+just release-summary  # From [Unreleased] in CHANGELOG
+```
+
+## CI Parity
+
+The devcontainer mirrors the CI environment (`ubuntu-latest`, Rust stable,
+`wasm32-unknown-unknown` target). Run `just ci` to reproduce the exact
+sequence that CI gates on before opening a PR.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `cargo: command not found` | Rebuild the devcontainer |
+| WASM target missing | Run `just bootstrap` |
+| `npx` not found | Ensure Node.js feature was installed |
+| Build errors after pull | Run `cargo clean && just ci` |

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
       }
     }
   },
-  "postCreateCommand": "rustup target add wasm32-unknown-unknown && cargo install just && just --list",
+  "postCreateCommand": "cargo install just && just bootstrap && just --list",
   "remoteUser": "vscode",
   "containerEnv": {
     "CARGO_TERM_COLOR": "always",

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ Thumbs.db
 *.tmp
 *.temp
 
+# Node tooling
+node_modules/
+
 # Environment secrets
 .env
 .env.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@
 
 ### Added
 - `docs/CONTRACT_MAINTENANCE_POLICY.md` — comprehensive maintenance policy covering `#[contracttype]` compatibility notes (#279), response-shape stability (#283), version negotiation (#284), API archetypes (#285), event payload size checks (#286), event drift review (#287), history write audit (#288), telemetry counters (#289), and role-change incident review (#290)
+- `docs/EVENT_DRIFT_CHECKLIST.md` — standalone quick-reference event drift review checklist for everyday maintainer use (#287)
 - `tooling/release-summary.ts` — release summary generator for maintainers (#280)
-- `.devcontainer/` — reproducible dev container workspace with Rust + WASM target + just + Node.js (#281)
+- `scripts/release-replay.ts` — minimal release candidate validation command for fast pre-release checks (#270)
+- `just release-replay` and `just release-replay-full` targets — fast and full release validation (#270)
+- `.devcontainer/` — reproducible dev container workspace with Rust + WASM target + just + Node.js, including setup README (#281)
 - `just bootstrap` target — one-command local environment setup (#281)
 - Historical parity checker test (`test_historical_parity_golden_results`) — validates current contract behavior against known golden results for release regression detection (#282)
 - `get_config_version_hash` — deterministic hash of the current config snapshot for backend parity validation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -513,7 +513,7 @@ This covers:
 - **[SC-504] Event Payload Size Check** (#286) — payload size assertions required
   for every event change.
 - **[SC-505] Event Drift Review Note** (#287) — checklist for event name/payload
-  changes.
+  changes. See also the [quick-reference checklist](docs/EVENT_DRIFT_CHECKLIST.md).
 - **[SC-506] History Write Audit Check** (#288) — FIFO ordering, pruning, and
   idempotency invariants.
 - **[SC-507] Telemetry Counters Policy** (#289) — additive-only counter fields,
@@ -531,7 +531,11 @@ for CI or `--check` for format validation.
 
 A `.devcontainer/` setup is provided for GitHub Codespaces and VS Code Dev
 Containers. The devcontainer includes Rust, the `wasm32-unknown-unknown` target,
-`just`, and Node.js. Run `just bootstrap` to set up your local environment.
+`just`, and Node.js. On first launch the devcontainer runs `just bootstrap`
+automatically. Run `just ci` to verify your environment matches CI.
+
+See [`.devcontainer/README.md`](.devcontainer/README.md) for detailed setup
+instructions.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ A [dev container](.devcontainer/) is provided for GitHub Codespaces and VS Code:
 # - Node.js + npx for tooling scripts
 ```
 
+See [`.devcontainer/README.md`](.devcontainer/README.md) for detailed instructions.
+
 ### Local Setup
 
 ```bash
@@ -87,6 +89,9 @@ just bootstrap
 
 # Run the full CI pipeline locally
 just ci
+
+# Fast release-candidate validation (before opening a PR)
+just release-replay
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed setup instructions.

--- a/apexchainx_calculator/src/calculation.rs
+++ b/apexchainx_calculator/src/calculation.rs
@@ -1,12 +1,10 @@
 use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 
 use crate::{
-    SLAConfig, SLAError, SLAResult, SLAStats, SeverityTelemetry,
-    STATS_KEY, HISTORY_KEY, RETENTION_LIMIT_KEY,
-    SEVERITY_CALC_COUNTS_KEY, SEVERITY_VIOL_COUNTS_KEY,
-    LAST_CALCULATION_LEDGER_KEY, LAST_VIOLATION_LEDGER_KEY,
-    PAUSED_KEY, MAX_HISTORY_SIZE, MAX_RECALCS_PER_OUTAGE,
-    EVENT_SLA_CALC, EVENT_SETTLE_INTENT, EVENT_VERSION, EVENT_STATS_SAT,
+    SLAConfig, SLAError, SLAResult, SLAStats, SeverityTelemetry, EVENT_SETTLE_INTENT, EVENT_SLA_CALC,
+    EVENT_VERSION, HISTORY_KEY, LAST_CALCULATION_LEDGER_KEY, LAST_VIOLATION_LEDGER_KEY, MAX_HISTORY_SIZE,
+    MAX_RECALCS_PER_OUTAGE, PAUSED_KEY, RETENTION_LIMIT_KEY, SEVERITY_CALC_COUNTS_KEY,
+    SEVERITY_VIOL_COUNTS_KEY, STATS_KEY,
 };
 
 /// Calculate the SLA outcome for an outage event (delegated implementation).
@@ -265,11 +263,7 @@ pub fn record_severity_telemetry(env: &Env, severity: &Symbol, met: bool) {
         count_lane(calculations, index).saturating_add(1),
     );
     if !met {
-        violations = set_count_lane(
-            violations,
-            index,
-            count_lane(violations, index).saturating_add(1),
-        );
+        violations = set_count_lane(violations, index, count_lane(violations, index).saturating_add(1));
     }
 
     let current_ledger = if now > u64::from(u32::MAX) {
@@ -307,12 +301,7 @@ pub fn increment_stats(env: &Env, met: bool, reward: i128, penalty: i128) {
     match stats.total_calculations.checked_add(1) {
         Some(v) => stats.total_calculations = v,
         None => {
-            emit_stats_saturated(
-                env,
-                symbol_short!("totcalc"),
-                stats.total_calculations as i128,
-                1,
-            );
+            emit_stats_saturated(env, symbol_short!("totcalc"), stats.total_calculations as i128, 1);
             stats.total_calculations = u64::MAX;
         }
     }
@@ -329,12 +318,7 @@ pub fn increment_stats(env: &Env, met: bool, reward: i128, penalty: i128) {
         match stats.total_violations.checked_add(1) {
             Some(v) => stats.total_violations = v,
             None => {
-                emit_stats_saturated(
-                    env,
-                    symbol_short!("totviol"),
-                    stats.total_violations as i128,
-                    1,
-                );
+                emit_stats_saturated(env, symbol_short!("totviol"), stats.total_violations as i128, 1);
                 stats.total_violations = u64::MAX;
             }
         }

--- a/apexchainx_calculator/src/config.rs
+++ b/apexchainx_calculator/src/config.rs
@@ -1,10 +1,8 @@
 use soroban_sdk::{symbol_short, Env, Map, Symbol, Vec};
 
 use crate::{
-    SLAConfig, SLAConfigEntry, SLAConfigSnapshot, SLAError,
-    CONFIG_KEY, CUSTOM_CONFIG_KEY,
-    EVENT_CONFIG_UPD, EVENT_VERSION,
-    config_freeze, config_metadata,
+    config_freeze, config_metadata, SLAConfig, SLAConfigEntry, SLAConfigSnapshot, SLAError, CONFIG_KEY,
+    CUSTOM_CONFIG_KEY, EVENT_CONFIG_UPD, EVENT_VERSION,
 };
 
 pub fn set_config(
@@ -17,7 +15,12 @@ pub fn set_config(
     crate::SLACalculatorContract::check_version(env)?;
     require_not_frozen(env)?;
 
-    crate::SLACalculatorContract::validate_config(&severity, threshold_minutes, penalty_per_minute, reward_base)?;
+    crate::SLACalculatorContract::validate_config(
+        &severity,
+        threshold_minutes,
+        penalty_per_minute,
+        reward_base,
+    )?;
 
     let mut configs: Map<Symbol, SLAConfig> = env
         .storage()
@@ -97,7 +100,11 @@ pub fn set_custom_severity(
         return Err(SLAError::InvalidSeverity);
     }
 
-    crate::SLACalculatorContract::validate_general_bounds(threshold_minutes, penalty_per_minute, reward_base)?;
+    crate::SLACalculatorContract::validate_general_bounds(
+        threshold_minutes,
+        penalty_per_minute,
+        reward_base,
+    )?;
 
     let mut custom: Map<Symbol, SLAConfig> = env
         .storage()

--- a/apexchainx_calculator/src/governance.rs
+++ b/apexchainx_calculator/src/governance.rs
@@ -1,16 +1,12 @@
 use soroban_sdk::{Address, Env};
 
 use crate::{
-    SLAError, ADMIN_KEY, PENDING_ADMIN_KEY, PENDING_OP_KEY, OPERATOR_KEY, EVENT_VERSION,
-    EVENT_ADMIN_PROP, EVENT_ADMIN_ACC, EVENT_ADMIN_CAN, EVENT_ADMIN_REN, EVENT_OP_PROP,
-    EVENT_OP_ACC, EVENT_OP_CAN, EVENT_OP_SET,
+    SLAError, ADMIN_KEY, EVENT_ADMIN_ACC, EVENT_ADMIN_CAN, EVENT_ADMIN_PROP, EVENT_ADMIN_REN, EVENT_OP_ACC,
+    EVENT_OP_CAN, EVENT_OP_PROP, EVENT_OP_SET, EVENT_VERSION, OPERATOR_KEY, PENDING_ADMIN_KEY,
+    PENDING_OP_KEY,
 };
 
-pub fn propose_admin(
-    env: &Env,
-    caller: &Address,
-    new_admin: &Address,
-) -> Result<(), SLAError> {
+pub fn propose_admin(env: &Env, caller: &Address, new_admin: &Address) -> Result<(), SLAError> {
     crate::SLACalculatorContract::check_version(env)?;
     crate::SLACalculatorContract::require_admin(env, caller)?;
     env.storage().instance().set(&PENDING_ADMIN_KEY, new_admin);
@@ -56,11 +52,7 @@ pub fn get_pending_admin(env: &Env) -> Result<Option<Address>, SLAError> {
     Ok(env.storage().instance().get(&PENDING_ADMIN_KEY))
 }
 
-pub fn propose_operator(
-    env: &Env,
-    caller: &Address,
-    new_operator: &Address,
-) -> Result<(), SLAError> {
+pub fn propose_operator(env: &Env, caller: &Address, new_operator: &Address) -> Result<(), SLAError> {
     crate::SLACalculatorContract::check_version(env)?;
     crate::SLACalculatorContract::require_admin(env, caller)?;
     env.storage().instance().set(&PENDING_OP_KEY, new_operator);
@@ -116,11 +108,7 @@ pub fn renounce_admin(env: &Env, caller: &Address) -> Result<(), SLAError> {
     Ok(())
 }
 
-pub fn set_operator(
-    env: &Env,
-    caller: &Address,
-    new_operator: &Address,
-) -> Result<(), SLAError> {
+pub fn set_operator(env: &Env, caller: &Address, new_operator: &Address) -> Result<(), SLAError> {
     crate::SLACalculatorContract::check_version(env)?;
     crate::SLACalculatorContract::require_admin(env, caller)?;
     env.storage().instance().set(&OPERATOR_KEY, new_operator);

--- a/apexchainx_calculator/src/history.rs
+++ b/apexchainx_calculator/src/history.rs
@@ -1,8 +1,8 @@
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
 use crate::{
-    SLAError, SLAResult,
-    HISTORY_KEY, RETENTION_LIMIT_KEY, MAX_HISTORY_SIZE, EVENT_VERSION, EVENT_PRUNED, EVENT_PRUNED_AGE,
+    SLAError, SLAResult, EVENT_PRUNED, EVENT_PRUNED_AGE, EVENT_VERSION, HISTORY_KEY, MAX_HISTORY_SIZE,
+    RETENTION_LIMIT_KEY,
 };
 
 pub fn get_history(env: &Env) -> Result<Vec<SLAResult>, SLAError> {
@@ -34,8 +34,10 @@ pub fn prune_history(env: &Env, caller: &Address, keep_latest: u32) -> Result<()
         }
 
         env.storage().instance().set(&HISTORY_KEY, &new_history);
-        env.events()
-            .publish((EVENT_PRUNED, EVENT_VERSION, caller.clone()), (remove_count, keep_latest));
+        env.events().publish(
+            (EVENT_PRUNED, EVENT_VERSION, caller.clone()),
+            (remove_count, keep_latest),
+        );
     }
 
     Ok(())

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -15,13 +15,13 @@ mod tests;
 mod fuzz_tests;
 
 pub mod audit_state;
+pub mod calculation;
 pub mod config;
 pub mod config_bundle;
 pub mod config_freeze;
 pub mod config_metadata;
 pub mod coordination_harness;
 pub mod cross_contract_safety;
-pub mod calculation;
 pub mod error_responses;
 pub mod event_correlation;
 mod event_schema;
@@ -1157,11 +1157,7 @@ impl SLACalculatorContract {
 
         // #92 – Cross-severity penalty ordering: enforce severity progression
         // so higher-severity penalties are never lower than lower-severity ones.
-        Self::validate_cross_severity_penalty_ordering(
-            &env,
-            &severity,
-            penalty_per_minute,
-        )?;
+        Self::validate_cross_severity_penalty_ordering(&env, &severity, penalty_per_minute)?;
 
         let mut configs: Map<Symbol, SLAConfig> = env
             .storage()
@@ -2147,8 +2143,7 @@ impl SLACalculatorContract {
             .get(&CONFIG_KEY)
             .ok_or(SLAError::NotInitialized)?;
 
-        let index = Self::canonical_severity_index(updated_severity)
-            .ok_or(SLAError::InvalidSeverity)?;
+        let index = Self::canonical_severity_index(updated_severity).ok_or(SLAError::InvalidSeverity)?;
         let severities = Self::canonical_severities(env);
 
         // Check against the next-lower severity (if any):
@@ -2166,7 +2161,7 @@ impl SLACalculatorContract {
         // the three higher tiers. Low (index 3) is exempt from this check
         // because its per-severity cap (100) intentionally exceeds medium's
         // minimum (10), making a strict `low <= medium` rule impossible.
-        if index >= 1 && index <= 2 {
+        if (1..=2).contains(&index) {
             let higher_sev = severities.get(index - 1).unwrap();
             if let Some(higher_cfg) = configs.get(higher_sev.clone()) {
                 if new_penalty > higher_cfg.penalty_per_minute {

--- a/apexchainx_calculator/src/metadata.rs
+++ b/apexchainx_calculator/src/metadata.rs
@@ -1,8 +1,8 @@
 use soroban_sdk::{Address, Env, String};
 
 use crate::{
-    SLAError, PauseInfo,
-    PAUSED_KEY, PAUSE_INFO_KEY, MAX_REASON_LEN, EVENT_VERSION, EVENT_PAUSED, EVENT_UNPAUSED,
+    PauseInfo, SLAError, EVENT_PAUSED, EVENT_UNPAUSED, EVENT_VERSION, MAX_REASON_LEN, PAUSED_KEY,
+    PAUSE_INFO_KEY,
 };
 
 pub fn pause(env: &Env, caller: &Address, reason: String) -> Result<(), SLAError> {

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -7024,9 +7024,15 @@ fn test_economic_exposure_returns_all_severities() {
     let (_env, client, _actors) = setup();
     let exposure = client.get_economic_exposure();
     assert_eq!(exposure.breakdown.len(), 4);
-    assert_eq!(exposure.breakdown.get(0).unwrap().severity, symbol_short!("critical"));
+    assert_eq!(
+        exposure.breakdown.get(0).unwrap().severity,
+        symbol_short!("critical")
+    );
     assert_eq!(exposure.breakdown.get(1).unwrap().severity, symbol_short!("high"));
-    assert_eq!(exposure.breakdown.get(2).unwrap().severity, symbol_short!("medium"));
+    assert_eq!(
+        exposure.breakdown.get(2).unwrap().severity,
+        symbol_short!("medium")
+    );
     assert_eq!(exposure.breakdown.get(3).unwrap().severity, symbol_short!("low"));
 }
 
@@ -7040,14 +7046,14 @@ fn test_economic_exposure_max_reward_matches_top_tier() {
     // Default configs: critical/high/medium → reward_base 750, low → 600
     // Top-tier (200 %): 750 * 200 / 100 = 1500; 600 * 200 / 100 = 1200
     let critical = exposure.breakdown.get(0).unwrap();
-    let high     = exposure.breakdown.get(1).unwrap();
-    let medium   = exposure.breakdown.get(2).unwrap();
-    let low      = exposure.breakdown.get(3).unwrap();
+    let high = exposure.breakdown.get(1).unwrap();
+    let medium = exposure.breakdown.get(2).unwrap();
+    let low = exposure.breakdown.get(3).unwrap();
 
     assert_eq!(critical.max_reward, 1500);
-    assert_eq!(high.max_reward,     1500);
-    assert_eq!(medium.max_reward,   1500);
-    assert_eq!(low.max_reward,      1200);
+    assert_eq!(high.max_reward, 1500);
+    assert_eq!(medium.max_reward, 1500);
+    assert_eq!(low.max_reward, 1200);
 }
 
 /// (c) `penalty_per_minute` for each severity matches the configured rate.
@@ -7058,14 +7064,14 @@ fn test_economic_exposure_penalty_rate_matches_config() {
 
     // Default penalty_per_minute: critical=100, high=50, medium=25, low=10
     let critical = exposure.breakdown.get(0).unwrap();
-    let high     = exposure.breakdown.get(1).unwrap();
-    let medium   = exposure.breakdown.get(2).unwrap();
-    let low      = exposure.breakdown.get(3).unwrap();
+    let high = exposure.breakdown.get(1).unwrap();
+    let medium = exposure.breakdown.get(2).unwrap();
+    let low = exposure.breakdown.get(3).unwrap();
 
     assert_eq!(critical.penalty_per_minute, 100);
-    assert_eq!(high.penalty_per_minute,      50);
-    assert_eq!(medium.penalty_per_minute,    25);
-    assert_eq!(low.penalty_per_minute,       10);
+    assert_eq!(high.penalty_per_minute, 50);
+    assert_eq!(medium.penalty_per_minute, 25);
+    assert_eq!(low.penalty_per_minute, 10);
 }
 
 /// (d) Aggregate `total_max_reward` equals the sum of per-severity max rewards.
@@ -7075,11 +7081,7 @@ fn test_economic_exposure_total_max_reward_is_sum_of_breakdown() {
     let exposure = client.get_economic_exposure();
 
     // Default: 1500 + 1500 + 1500 + 1200 = 5700
-    let expected_total: i128 = exposure
-        .breakdown
-        .iter()
-        .map(|e| e.max_reward)
-        .sum();
+    let expected_total: i128 = exposure.breakdown.iter().map(|e| e.max_reward).sum();
     assert_eq!(exposure.total_max_reward, expected_total);
     assert_eq!(exposure.total_max_reward, 5700);
 }
@@ -7092,11 +7094,7 @@ fn test_economic_exposure_total_penalty_per_minute_is_sum_of_breakdown() {
     let exposure = client.get_economic_exposure();
 
     // Default: 100 + 50 + 25 + 10 = 185
-    let expected_total: i128 = exposure
-        .breakdown
-        .iter()
-        .map(|e| e.penalty_per_minute)
-        .sum();
+    let expected_total: i128 = exposure.breakdown.iter().map(|e| e.penalty_per_minute).sum();
     assert_eq!(exposure.total_penalty_per_minute, expected_total);
     assert_eq!(exposure.total_penalty_per_minute, 185);
 }
@@ -7112,7 +7110,7 @@ fn test_economic_exposure_reflects_config_change() {
     let exposure = client.get_economic_exposure();
     let critical = exposure.breakdown.get(0).unwrap();
 
-    assert_eq!(critical.max_reward,        2000);
+    assert_eq!(critical.max_reward, 2000);
     assert_eq!(critical.penalty_per_minute, 200);
 
     // Totals must also update: was 5700 reward, now (2000 + 1500 + 1500 + 1200) = 6200
@@ -7140,8 +7138,18 @@ fn test_economic_exposure_independent_of_history() {
 
     // Run a couple of calculations to populate history
     env.mock_all_auths();
-    client.calculate_sla(&actors.operator, &symbol_short!("out001"), &symbol_short!("critical"), &5);
-    client.calculate_sla(&actors.operator, &symbol_short!("out002"), &symbol_short!("high"), &40);
+    client.calculate_sla(
+        &actors.operator,
+        &symbol_short!("out001"),
+        &symbol_short!("critical"),
+        &5,
+    );
+    client.calculate_sla(
+        &actors.operator,
+        &symbol_short!("out002"),
+        &symbol_short!("high"),
+        &40,
+    );
 
     let exposure_before = client.get_economic_exposure();
 
@@ -7208,7 +7216,7 @@ fn test_healthcheck_is_deterministic() {
 
 #[test]
 fn test_healthcheck_does_not_mutate_state() {
-    let (_env, client, actors) = setup();
+    let (_env, client, _actors) = setup();
     let stats_before = client.get_stats();
     let _hc = client.healthcheck();
     let stats_after = client.get_stats();
@@ -7232,7 +7240,7 @@ fn test_healthcheck_does_not_require_auth() {
 
 #[test]
 fn test_historical_parity_golden_results() {
-    let (_env, client, actors) = setup();
+    let (_env, client, _actors) = setup();
 
     // Golden result set: known-good outputs for specific inputs.
     // These must NEVER change between releases — if they do, it's a regression.
@@ -7246,18 +7254,102 @@ fn test_historical_parity_golden_results() {
     }
 
     let golden = [
-        Golden { outage_id: "HP001", severity: "critical", mttr: 5,  expected_status: "met",  expected_amount: 1500, expected_rating: "top" },
-        Golden { outage_id: "HP002", severity: "critical", mttr: 15, expected_status: "met",  expected_amount: 750,  expected_rating: "good" },
-        Golden { outage_id: "HP003", severity: "critical", mttr: 20, expected_status: "viol", expected_amount: -500, expected_rating: "poor" },
-        Golden { outage_id: "HP004", severity: "high",     mttr: 10, expected_status: "met",  expected_amount: 1500, expected_rating: "top" },
-        Golden { outage_id: "HP005", severity: "high",     mttr: 30, expected_status: "met",  expected_amount: 750,  expected_rating: "good" },
-        Golden { outage_id: "HP006", severity: "high",     mttr: 40, expected_status: "viol", expected_amount: -500, expected_rating: "poor" },
-        Golden { outage_id: "HP007", severity: "medium",   mttr: 20, expected_status: "met",  expected_amount: 1500, expected_rating: "top" },
-        Golden { outage_id: "HP008", severity: "medium",   mttr: 60, expected_status: "met",  expected_amount: 750,  expected_rating: "good" },
-        Golden { outage_id: "HP009", severity: "medium",   mttr: 80, expected_status: "viol", expected_amount: -500, expected_rating: "poor" },
-        Golden { outage_id: "HP010", severity: "low",      mttr: 40, expected_status: "met",  expected_amount: 1200, expected_rating: "top" },
-        Golden { outage_id: "HP011", severity: "low",      mttr: 120,expected_status: "met",  expected_amount: 600,  expected_rating: "good" },
-        Golden { outage_id: "HP012", severity: "low",      mttr: 150,expected_status: "viol", expected_amount: -300, expected_rating: "poor" },
+        Golden {
+            outage_id: "HP001",
+            severity: "critical",
+            mttr: 5,
+            expected_status: "met",
+            expected_amount: 1500,
+            expected_rating: "top",
+        },
+        Golden {
+            outage_id: "HP002",
+            severity: "critical",
+            mttr: 15,
+            expected_status: "met",
+            expected_amount: 750,
+            expected_rating: "good",
+        },
+        Golden {
+            outage_id: "HP003",
+            severity: "critical",
+            mttr: 20,
+            expected_status: "viol",
+            expected_amount: -500,
+            expected_rating: "poor",
+        },
+        Golden {
+            outage_id: "HP004",
+            severity: "high",
+            mttr: 10,
+            expected_status: "met",
+            expected_amount: 1500,
+            expected_rating: "top",
+        },
+        Golden {
+            outage_id: "HP005",
+            severity: "high",
+            mttr: 30,
+            expected_status: "met",
+            expected_amount: 750,
+            expected_rating: "good",
+        },
+        Golden {
+            outage_id: "HP006",
+            severity: "high",
+            mttr: 40,
+            expected_status: "viol",
+            expected_amount: -500,
+            expected_rating: "poor",
+        },
+        Golden {
+            outage_id: "HP007",
+            severity: "medium",
+            mttr: 20,
+            expected_status: "met",
+            expected_amount: 1500,
+            expected_rating: "top",
+        },
+        Golden {
+            outage_id: "HP008",
+            severity: "medium",
+            mttr: 60,
+            expected_status: "met",
+            expected_amount: 750,
+            expected_rating: "good",
+        },
+        Golden {
+            outage_id: "HP009",
+            severity: "medium",
+            mttr: 80,
+            expected_status: "viol",
+            expected_amount: -500,
+            expected_rating: "poor",
+        },
+        Golden {
+            outage_id: "HP010",
+            severity: "low",
+            mttr: 40,
+            expected_status: "met",
+            expected_amount: 1200,
+            expected_rating: "top",
+        },
+        Golden {
+            outage_id: "HP011",
+            severity: "low",
+            mttr: 120,
+            expected_status: "met",
+            expected_amount: 600,
+            expected_rating: "good",
+        },
+        Golden {
+            outage_id: "HP012",
+            severity: "low",
+            mttr: 150,
+            expected_status: "viol",
+            expected_amount: -300,
+            expected_rating: "poor",
+        },
     ];
 
     for g in golden.iter() {
@@ -7267,21 +7359,47 @@ fn test_historical_parity_golden_results() {
         // Use view to avoid mutating state and to verify that the view path
         // also produces the same golden results.
         let view = client.calculate_sla_view(&oid, &sev, &g.mttr);
-        assert_eq!(view.status, Symbol::new(&_env, g.expected_status),
-            "Golden mismatch: {} {} mttr={} — status", g.outage_id, g.severity, g.mttr);
-        assert_eq!(view.amount, g.expected_amount,
-            "Golden mismatch: {} {} mttr={} — amount", g.outage_id, g.severity, g.mttr);
-        assert_eq!(view.rating, Symbol::new(&_env, g.expected_rating),
-            "Golden mismatch: {} {} mttr={} — rating", g.outage_id, g.severity, g.mttr);
+        assert_eq!(
+            view.status,
+            Symbol::new(&_env, g.expected_status),
+            "Golden mismatch: {} {} mttr={} — status",
+            g.outage_id,
+            g.severity,
+            g.mttr
+        );
+        assert_eq!(
+            view.amount, g.expected_amount,
+            "Golden mismatch: {} {} mttr={} — amount",
+            g.outage_id, g.severity, g.mttr
+        );
+        assert_eq!(
+            view.rating,
+            Symbol::new(&_env, g.expected_rating),
+            "Golden mismatch: {} {} mttr={} — rating",
+            g.outage_id,
+            g.severity,
+            g.mttr
+        );
     }
 
     // Also validate that the config snapshot is historically stable
     let snapshot = client.get_config_snapshot();
-    assert_eq!(snapshot.version, symbol_short!("v1"), "Config snapshot version changed");
+    assert_eq!(
+        snapshot.version,
+        symbol_short!("v1"),
+        "Config snapshot version changed"
+    );
     assert_eq!(snapshot.entries.len(), 4, "Config snapshot entry count changed");
 
     // Validate result schema stability
     let schema = client.get_result_schema();
-    assert_eq!(schema.schema_version, 1, "Result schema version changed — check migration notes");
-    assert_eq!(schema.deprecated_symbols.len(), 0, "Unexpected deprecated symbols in v1");
+    assert_eq!(
+        schema.schema_version, 1,
+        "Result schema version changed — check migration notes"
+    );
+    assert_eq!(
+        schema.deprecated_symbols.len(),
+        0,
+        "Unexpected deprecated symbols in v1"
+    );
 }

--- a/docs/EVENT_DRIFT_CHECKLIST.md
+++ b/docs/EVENT_DRIFT_CHECKLIST.md
@@ -1,0 +1,71 @@
+# Event Drift Review Checklist
+
+> **Quick reference for maintainers.** Use this during code review whenever a PR
+> touches `EVENT_*` constants, event emission sites, or `event_schema.rs`.
+
+---
+
+## 🔍 What Is Event Drift?
+
+Event drift is a **silent compatibility break** — no compilation error, no test
+failure, just corrupted downstream data. A renamed topic, reordered payload
+field, or changed field type breaks every backend indexer that deserialises
+contract events by position.
+
+---
+
+## ✅ Review Checklist
+
+### Topic Stability (names + versions)
+
+- [ ] **No event name changed** without bumping `EVENT_VERSION` (`"v1"` → `"v2"`)
+- [ ] **No event removed** from emission without a deprecation period
+- [ ] **New events use unique names** — never reuse old event name constants
+- [ ] **3-topic layout preserved** — all events emit `(name, version, context)`
+- [ ] **`test_event_names_are_distinct` updated** — new events added to the array
+
+### Payload Stability (fields + types)
+
+- [ ] **No field removed** from an existing payload tuple
+- [ ] **No field reordered** — new fields always appended at the end
+- [ ] **No field type changed** (e.g. `u32` → `u64`) without a version bump
+- [ ] **All emission sites consistent** — search for the event name and verify
+      every `publish()` call emits the same tuple shape
+
+### Documentation
+
+- [ ] **`event_schema.rs` doc comment updated** — payload layout documented with
+      field names and types
+- [ ] **`docs/EVENT_TOPIC_COMPATIBILITY.md` event catalog updated** — new or
+      changed events reflected in the catalog tables
+- [ ] **`docs/AUDIT_TRAIL.md` updated** — new emission sites and backend
+      recovery implications documented
+
+### Testing
+
+- [ ] **Topic stability tests pass:** `cargo test topic_stability_tests`
+- [ ] **Event names distinctness test updated**
+- [ ] **Payload size assertions added** for new/modified event payloads
+
+---
+
+## 📋 Version Bump Decision Table
+
+| Change | Bump `EVENT_VERSION`? |
+|--------|:---:|
+| New event constant added | ❌ No (additive) |
+| Existing event renamed | ✅ Yes |
+| New field appended to payload end | ❌ No (additive) |
+| Field removed from payload | ✅ Yes |
+| Field reordered in payload | ✅ Yes |
+| Field type changed | ✅ Yes |
+| Event emission removed | ✅ Yes (major) |
+
+---
+
+## 🔗 Related Policies
+
+- [Contract Maintenance Policy: SC-505](./CONTRACT_MAINTENANCE_POLICY.md#sc-505-event-drift-review-note) — full policy text
+- [Event Topic Compatibility Policy](./EVENT_TOPIC_COMPATIBILITY.md) — formal backend contract
+- [Event Payload Compatibility Policy](./EVENT_COMPATIBILITY_POLICY.md) — field ordering rules
+- [Contributor Safety Checklist (SC-099)](../CONTRIBUTING.md#sc-099-event-topic--payload-schema-contributor-safety-checklist) — detailed PR review checklist

--- a/justfile
+++ b/justfile
@@ -90,7 +90,18 @@ hash: wasm-release
         shasum -a 256 "$wasm" | awk '{print $1 "  {{crate}}.wasm"}'
     fi
 
-# --------------------------------------------------------------- tooling -----
+# ----------------------------------------------------------- release ------
+
+# Minimal release candidate validation (fast).  [CI: Release Replay]
+# Runs format, clippy, no-std, core tests, topic-stability, and WASM build.
+# Use release-replay-full for fuzz + full test suite.
+release-replay:
+    npx --yes tsx scripts/release-replay.ts
+
+release-replay-full:
+    npx --yes tsx scripts/release-replay.ts --full
+
+# --------------------------------------------------------------- tooling ------
 
 # Generate a ship-review note from CHANGELOG.md.
 # Pass a version tag to summarise a released block: just release-summary 0.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,928 @@
+{
+  "name": "apexchainx-contracts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "apexchainx-contracts",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@types/node": "^26.1.2",
+        "tsx": "^4.23.1",
+        "typescript": "^7.0.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "apexchainx-contracts",
+  "version": "0.1.0",
+  "private": true,
+  "description": "ApexChainx smart contract tooling — TypeScript scripts for CI, testing, and release validation",
+  "scripts": {
+    "test": "tsx --test scripts/release-replay.test.ts",
+    "release-replay": "tsx scripts/release-replay.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^26.1.2",
+    "tsx": "^4.23.1",
+    "typescript": "^7.0.2"
+  }
+}

--- a/scripts/release-replay.test.ts
+++ b/scripts/release-replay.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Smoke tests for the release-replay script.
+ *
+ * Verifies the script can be imported, its CLI interface works end-to-end,
+ * and helper functions return correct data shapes.
+ *
+ * Run from repo root:
+ *   npx tsx --test scripts/release-replay.test.ts
+ */
+
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import test from "node:test";
+
+import { runStep, StepResult, ReplayResult } from "./release-replay.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SCRIPT_PATH = path.resolve(__dirname, "release-replay.ts");
+
+function runReleaseReplay(args: string): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execSync(`npx tsx ${SCRIPT_PATH} ${args}`, {
+      cwd: path.resolve(__dirname, ".."),
+      timeout: 30_000,
+      stdio: "pipe",
+    });
+    return { stdout: stdout.toString(), stderr: "", exitCode: 0 };
+  } catch (err: any) {
+    return {
+      stdout: err.stdout?.toString() || "",
+      stderr: err.stderr?.toString() || "",
+      exitCode: err.status || 1,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI interface smoke tests
+// ---------------------------------------------------------------------------
+
+test("--help prints usage and exits 0", () => {
+  const result = runReleaseReplay("--help");
+
+  assert.equal(result.exitCode, 0, "--help should exit with code 0");
+  assert.ok(
+    result.stdout.includes("ApexChainx Release Replay"),
+    "should include script name"
+  );
+  assert.ok(
+    result.stdout.includes("Usage:"),
+    "should include usage section"
+  );
+  assert.ok(
+    result.stdout.includes("--full"),
+    "should document --full flag"
+  );
+  assert.ok(
+    result.stdout.includes("--json"),
+    "should document --json flag"
+  );
+  assert.ok(
+    result.stdout.includes("RELEASE_PROVENANCE_POLICY"),
+    "should reference provenance policy"
+  );
+});
+
+test("-h (short flag) prints usage and exits 0", () => {
+  const result = runReleaseReplay("-h");
+
+  assert.equal(result.exitCode, 0, "-h should exit with code 0");
+  assert.ok(
+    result.stdout.includes("Usage:"),
+    "short flag should print usage"
+  );
+});
+
+test("unknown flag does not crash; it attempts to run", () => {
+  const result = runReleaseReplay("--unknown-flag");
+
+  // The script doesn't validate unknown flags — it just passes them through.
+  // It should still start up and attempt execution (exit code may vary).
+  assert.ok(
+    result.exitCode !== null,
+    "should produce some exit code"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// JSON output smoke test
+// ---------------------------------------------------------------------------
+
+test("--json flag with --help prints help and exits 0 (help takes precedence)", () => {
+  const result = runReleaseReplay("--json --help");
+
+  // Help takes precedence over --json in the current implementation,
+  // so exit 0 with help text (not JSON).
+  assert.equal(result.exitCode, 0);
+  assert.ok(
+    result.stdout.includes("Usage:"),
+    "help text should appear"
+  );
+});
+
+// ---------------------------------------------------------------------------
+// runStep unit tests
+// ---------------------------------------------------------------------------
+
+test("runStep returns success for a passing command", () => {
+  const result = runStep("Echo test", "echo hello");
+
+  assert.equal(result.success, true);
+  assert.equal(result.step, "Echo test");
+  assert.equal(result.command, "echo hello");
+  assert.ok(result.durationMs >= 0, "duration should be non-negative");
+  assert.equal(result.error, undefined, "no error on success");
+});
+
+test("runStep returns failure for a failing command", () => {
+  const result = runStep("Failing test", "exit 1");
+
+  assert.equal(result.success, false);
+  assert.equal(result.step, "Failing test");
+  assert.ok(result.durationMs >= 0, "duration should be non-negative");
+  assert.ok(result.error, "error should be present on failure");
+  assert.ok(
+    result.error!.length > 0,
+    "error message should not be empty"
+  );
+});
+
+test("runStep returns failure for a nonexistent command", () => {
+  const result = runStep(
+    "Nonexistent",
+    "this_command_definitely_does_not_exist_12345"
+  );
+
+  assert.equal(result.success, false);
+  assert.ok(result.error, "error should be present");
+});
+
+// ---------------------------------------------------------------------------
+// Type shape validation
+// ---------------------------------------------------------------------------
+
+test("StepResult has correct shape on success", () => {
+  const result = runStep("Type check", "echo ok");
+
+  // Verify the object meets the StepResult interface
+  assert.equal(typeof result.step, "string");
+  assert.equal(typeof result.command, "string");
+  assert.equal(typeof result.success, "boolean");
+  assert.equal(typeof result.durationMs, "number");
+  assert.equal(result.success, true);
+  assert.equal(result.error, undefined);
+});
+
+test("StepResult has correct shape on failure", () => {
+  const result = runStep("Type check fail", "exit 2");
+
+  assert.equal(typeof result.step, "string");
+  assert.equal(typeof result.command, "string");
+  assert.equal(typeof result.success, "boolean");
+  assert.equal(typeof result.durationMs, "number");
+  assert.equal(result.success, false);
+  assert.equal(typeof result.error, "string");
+});
+
+test("ReplayResult interface is structurally sound", () => {
+  // Verify a manually constructed result matches the interface
+  const result: ReplayResult = {
+    passed: true,
+    totalSteps: 1,
+    passedSteps: 1,
+    failedSteps: 0,
+    totalDurationMs: 42,
+    steps: [
+      {
+        step: "test",
+        command: "echo test",
+        success: true,
+        durationMs: 42,
+      },
+    ],
+    generatedAt: new Date().toISOString(),
+  };
+
+  assert.equal(result.passed, true);
+  assert.equal(result.totalSteps, 1);
+  assert.equal(result.failedSteps, 0);
+  assert.ok(Date.parse(result.generatedAt) > 0, "generatedAt should be valid ISO");
+  assert.equal(result.steps.length, 1);
+  assert.equal(result.steps[0].step, "test");
+});
+
+// ---------------------------------------------------------------------------
+// Real (fast) end-to-end: just release-replay via justfile
+// ---------------------------------------------------------------------------
+
+test("just release-replay runs the script end-to-end", () => {
+  let result: { stdout: string; exitCode: number };
+  try {
+    const stdout = execSync("just release-replay", {
+      cwd: path.resolve(__dirname, ".."),
+      timeout: 300_000, // 5 minutes — real cargo commands
+      stdio: "pipe",
+    });
+    result = { stdout: stdout.toString(), exitCode: 0 };
+  } catch (err: any) {
+    result = {
+      stdout: err.stdout?.toString() || "",
+      exitCode: err.status || 1,
+    };
+  }
+
+  assert.ok(
+    result.stdout.includes("🔁 ApexChainx Release Replay"),
+    "should show replay header"
+  );
+  assert.ok(
+    result.stdout.includes("Minimal") || result.stdout.includes("Full"),
+    "should indicate validation mode"
+  );
+
+  // The exit code reflects whether all steps passed (0) or some failed (1).
+  // Both are valid — we just verify the script ran.
+  assert.ok(
+    result.exitCode === 0 || result.exitCode === 1,
+    `unexpected exit code: ${result.exitCode}`
+  );
+});

--- a/scripts/release-replay.ts
+++ b/scripts/release-replay.ts
@@ -31,7 +31,7 @@ import * as path from "path";
 // Types
 // ---------------------------------------------------------------------------
 
-interface StepResult {
+export interface StepResult {
   step: string;
   command: string;
   success: boolean;
@@ -39,7 +39,7 @@ interface StepResult {
   error?: string;
 }
 
-interface ReplayResult {
+export interface ReplayResult {
   passed: boolean;
   totalSteps: number;
   passedSteps: number;
@@ -66,7 +66,7 @@ const opts: ExecSyncOptions = {
 // Step runner
 // ---------------------------------------------------------------------------
 
-function runStep(step: string, command: string, cwd?: string): StepResult {
+export function runStep(step: string, command: string, cwd?: string): StepResult {
   const start = Date.now();
   const stepOpts: ExecSyncOptions = { ...opts };
   if (cwd) stepOpts.cwd = path.resolve(process.cwd(), cwd);
@@ -193,4 +193,8 @@ function main(): void {
   process.exit(result.passed ? 0 : 1);
 }
 
-main();
+// Run main() only when executed directly, not when imported for testing.
+const scriptPath = process.argv[1] ?? "";
+if (scriptPath.endsWith("release-replay.ts") || scriptPath.endsWith("release-replay.js")) {
+  main();
+}

--- a/scripts/release-replay.ts
+++ b/scripts/release-replay.ts
@@ -1,0 +1,196 @@
+/**
+ * release-replay.ts
+ *
+ * Minimal release candidate validation command for maintainers.
+ * Runs a fast, focused sequence that validates the most critical
+ * release-readiness checks without the full CI pipeline duration.
+ *
+ * Usage (run from repo root):
+ *   npx tsx scripts/release-replay.ts
+ *
+ * Or via just:
+ *   just release-replay
+ *
+ * What it checks:
+ *   1. Format compliance (cargo fmt --check)
+ *   2. Clippy warnings denied
+ *   3. no-std compliance for wasm32 target
+ *   4. Core library tests
+ *   5. Topic stability tests
+ *   6. WASM build
+ *
+ * Optional flags:
+ *   --full     Also run fuzz tests and full test suite (equivalent to just ci)
+ *   --json     Output results as JSON for CI consumption
+ */
+
+import { execSync, ExecSyncOptions } from "child_process";
+import * as path from "path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface StepResult {
+  step: string;
+  command: string;
+  success: boolean;
+  durationMs: number;
+  error?: string;
+}
+
+interface ReplayResult {
+  passed: boolean;
+  totalSteps: number;
+  passedSteps: number;
+  failedSteps: number;
+  totalDurationMs: number;
+  steps: StepResult[];
+  generatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const CRATE_DIR = "apexchainx_calculator";
+const WASM_TARGET = "wasm32-unknown-unknown";
+
+const opts: ExecSyncOptions = {
+  stdio: "pipe",
+  cwd: process.cwd(),
+  timeout: 120_000, // 2 minutes per step
+};
+
+// ---------------------------------------------------------------------------
+// Step runner
+// ---------------------------------------------------------------------------
+
+function runStep(step: string, command: string, cwd?: string): StepResult {
+  const start = Date.now();
+  const stepOpts: ExecSyncOptions = { ...opts };
+  if (cwd) stepOpts.cwd = path.resolve(process.cwd(), cwd);
+
+  process.stdout.write(`  ⏳ ${step}... `);
+
+  try {
+    execSync(command, stepOpts);
+    const durationMs = Date.now() - start;
+    console.log(`✅ (${(durationMs / 1000).toFixed(1)}s)`);
+    return { step, command, success: true, durationMs };
+  } catch (err: unknown) {
+    const durationMs = Date.now() - start;
+    let error: string;
+    if (err instanceof Error) {
+      error = (err as any).stderr?.toString() || err.message;
+    } else {
+      error = String(err);
+    }
+    console.log(`❌ (${(durationMs / 1000).toFixed(1)}s)`);
+    return { step, command, success: false, durationMs, error };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const full = args.includes("--full");
+  const json = args.includes("--json");
+
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(
+      "ApexChainx Release Replay — minimal release candidate validation\n" +
+      "\nUsage:\n" +
+      "  npx tsx scripts/release-replay.ts [--full] [--json]\n" +
+      "\nOptions:\n" +
+      "  --full   Run fuzz tests + full test suite (slower but comprehensive)\n" +
+      "  --json   Output results as JSON\n" +
+      "\nSee docs/RELEASE_PROVENANCE_POLICY.md for full release procedures.\n"
+    );
+    process.exit(0);
+  }
+
+  console.log("\n🔁 ApexChainx Release Replay");
+  console.log(`   ${full ? "Full" : "Minimal"} validation sequence`);
+  console.log(`   Started: ${new Date().toISOString()}\n`);
+
+  const steps: StepResult[] = [];
+
+  // Always run the core checks
+  steps.push(
+    runStep("Format check", "cargo fmt --check", CRATE_DIR)
+  );
+  steps.push(
+    runStep("Clippy lint", "cargo clippy --all-targets -- -D warnings", CRATE_DIR)
+  );
+  steps.push(
+    runStep("no-std check", `cargo check --target ${WASM_TARGET} --lib`, CRATE_DIR)
+  );
+  steps.push(
+    runStep("Core tests", "cargo test --lib", CRATE_DIR)
+  );
+  steps.push(
+    runStep("Topic stability tests", "cargo test topic_stability_tests", CRATE_DIR)
+  );
+  steps.push(
+    runStep("WASM build", `cargo build --target ${WASM_TARGET}`, CRATE_DIR)
+  );
+
+  // Optional full checks
+  if (full) {
+    steps.push(
+      runStep("Fuzz tests", "cargo test --lib fuzz_tests::", CRATE_DIR)
+    );
+    steps.push(
+      runStep("Full test suite", "cargo test", CRATE_DIR)
+    );
+    steps.push(
+      runStep("WASM release build", `cargo build --target ${WASM_TARGET} --release`, CRATE_DIR)
+    );
+  }
+
+  // Summarize
+  const passedSteps = steps.filter((s) => s.success).length;
+  const failedSteps = steps.filter((s) => !s.success).length;
+  const totalDurationMs = steps.reduce((sum, s) => sum + s.durationMs, 0);
+
+  const result: ReplayResult = {
+    passed: failedSteps === 0,
+    totalSteps: steps.length,
+    passedSteps,
+    failedSteps,
+    totalDurationMs,
+    steps,
+    generatedAt: new Date().toISOString(),
+  };
+
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log("─".repeat(62));
+    console.log(`  ${result.passed ? "✅ ALL PASSED" : "❌ FAILURES DETECTED"}`);
+    console.log(`  ${passedSteps}/${result.totalSteps} steps passed`);
+    console.log(`  Duration: ${(totalDurationMs / 1000).toFixed(1)}s`);
+    console.log("─".repeat(62));
+
+    // Print failures
+    for (const step of steps) {
+      if (!step.success) {
+        console.log(`\n❌ ${step.step}:`);
+        console.log(`   Command: ${step.command}`);
+        if (step.error) {
+          const truncated = step.error.slice(0, 500);
+          console.log(`   Error: ${truncated}`);
+        }
+      }
+    }
+    console.log();
+  }
+
+  process.exit(result.passed ? 0 : 1);
+}
+
+main();

--- a/scripts/release-replay.ts
+++ b/scripts/release-replay.ts
@@ -56,19 +56,23 @@ export interface ReplayResult {
 const CRATE_DIR = "apexchainx_calculator";
 const WASM_TARGET = "wasm32-unknown-unknown";
 
+const DEFAULT_TIMEOUT_MS = 600_000; // 10 minutes per step
+const MAX_BUFFER = 10 * 1024 * 1024; // 10 MB for verbose cargo output
+
 const opts: ExecSyncOptions = {
   stdio: "pipe",
   cwd: process.cwd(),
-  timeout: 120_000, // 2 minutes per step
+  timeout: DEFAULT_TIMEOUT_MS,
+  maxBuffer: MAX_BUFFER,
 };
 
 // ---------------------------------------------------------------------------
 // Step runner
 // ---------------------------------------------------------------------------
 
-export function runStep(step: string, command: string, cwd?: string): StepResult {
+export function runStep(step: string, command: string, cwd?: string, timeoutMs?: number): StepResult {
   const start = Date.now();
-  const stepOpts: ExecSyncOptions = { ...opts };
+  const stepOpts: ExecSyncOptions = { ...opts, timeout: timeoutMs ?? DEFAULT_TIMEOUT_MS };
   if (cwd) stepOpts.cwd = path.resolve(process.cwd(), cwd);
 
   process.stdout.write(`  ⏳ ${step}... `);


### PR DESCRIPTION
## Summary

Resolves three issues assigned to @Syringe7 in a single PR.

---

### #287 — Add a dedicated event drift review note

**Created** `docs/EVENT_DRIFT_CHECKLIST.md` — a standalone quick-reference checklist for maintainers covering:
- Topic stability (names + versions)
- Payload stability (fields + types)
- Documentation requirements
- Testing requirements
- Version bump decision table

Linked from `CONTRIBUTING.md` SC-505 entry for easy discovery during code review.

---

### #281 — Create a contract devcontainer or workspace bootstrap improvement

**Created** `.devcontainer/README.md` — detailed setup guide for Codespaces and VS Code with:
- What’s included table
- Getting started steps for both Codespaces and VS Code
- Daily workflow commands
- CI parity explanation
- Troubleshooting section

**Updated** `.devcontainer/devcontainer.json`:
- Cleaned up redundant `rustup target add` call (already handled by `just bootstrap`)
- `postCreateCommand` now runs `just bootstrap` automatically

**Updated** `CONTRIBUTING.md` and `README.md` with links to the devcontainer README.

---

### #270 — Introduce a minimal release replay command

**Created** `scripts/release-replay.ts` — TypeScript script that runs a fast, focused release candidate validation:
1. Format compliance (`cargo fmt --check`)
2. Clippy warnings denied
3. no-std compliance for wasm32 target
4. Core library tests
5. Topic stability tests
6. WASM build

Supports `--full` (adds fuzz tests + full suite + release WASM build) and `--json` (CI-friendly output).

**Added** `just release-replay` and `just release-replay-full` targets to `justfile`.

**Updated** `README.md` to document the new commands.

---

### Files Changed

| File | Change |
|------|--------|
| `docs/EVENT_DRIFT_CHECKLIST.md` | **New** — event drift review checklist (#287) |
| `.devcontainer/README.md` | **New** — devcontainer setup guide (#281) |
| `scripts/release-replay.ts` | **New** — release replay command (#270) |
| `.devcontainer/devcontainer.json` | **Modified** — clean up + run just bootstrap (#281) |
| `justfile` | **Modified** — add release-replay targets (#270) |
| `CONTRIBUTING.md` | **Modified** — link drift checklist + devcontainer README (#287, #281) |
| `README.md` | **Modified** — link devcontainer README + release-replay docs (#281, #270) |
| `CHANGELOG.md` | **Modified** — add entries for all three changes |

---

Closes #287
Closes #281
Closes #270