### PR TITLE
feat(#261): add contract state fingerprint helper

### DIFF
--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -624,6 +624,38 @@ pub struct HealthcheckResult {
     pub status: Symbol,
 }
 
+/// #261 – Contract state fingerprint for release review and upgrade planning.
+///
+/// Provides a compact, deterministic snapshot of the contract's live state by
+/// combining storage version, configuration hash, pause state, and migration
+/// posture into a single reviewable summary. This is safe to call on a live
+/// contract without mutating state.
+///
+/// Backend consumers can call this before and after upgrades or during incident
+/// response to quickly audit the contract's current posture without issuing
+/// separate queries for each field.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractStateFingerprint {
+    /// Human-readable contract name for log correlation.
+    pub contract_name: Symbol,
+    /// Storage schema version stamped in contract storage.
+    pub storage_version: u32,
+    /// Result schema version for SLAResult field layout.
+    pub result_schema_version: u32,
+    /// Deterministic hash of the current configuration snapshot.
+    /// Changes whenever set_config is called with different values.
+    pub config_version_hash: u64,
+    /// True when the contract is currently paused.
+    pub is_paused: bool,
+    /// True when stored storage version differs from the binary's expected version.
+    pub needs_migration: bool,
+    /// True when the configuration is frozen (admin cannot call set_config).
+    pub is_config_frozen: bool,
+    /// Ledger timestamp when this fingerprint was captured (seconds).
+    pub captured_at: u64,
+}
+
 /// SC-W5-029 – Combined version negotiation response for backend startup handshake.
 ///
 /// Backend consumers call `get_version_info` once at startup (or after an upgrade)
@@ -2684,5 +2716,88 @@ impl SLACalculatorContract {
             contract_name: symbol_short!("sla_calc"),
             status,
         }
+    }
+
+    // -------------------------------------------------------------------
+    // #261 – Contract state fingerprint for release review and upgrade planning
+    // -------------------------------------------------------------------
+
+    /// Returns a compact, deterministic snapshot of the contract's live state.
+    ///
+    /// Combines storage version, configuration hash, pause state, configuration
+    /// freeze state, and migration posture into a single fingerprint object.
+    /// This is a read-only view that does **not** require authentication,
+    /// does **not** mutate state, and does **not** emit events.
+    ///
+    /// # Use Cases
+    ///
+    /// - **Pre-upgrade audit**: capture the fingerprint before deploying a new
+    ///   contract version, then compare it against the post-upgrade fingerprint
+    ///   to verify only expected state changed.
+    /// - **Incident response**: quickly surface the contract's posture during an
+    ///   incident without issuing separate queries for version, config, pause, etc.
+    /// - **Backend health checks**: backends can cache this fingerprint and poll
+    ///   it periodically to detect unexpected state drift (e.g., an admin paused
+    ///   the contract or froze the config without notifying the backend).
+    ///
+    /// # Returns
+    ///
+    /// A `ContractStateFingerprint` containing:
+    /// - `contract_name`: fixed to "sla_calc"
+    /// - `storage_version`: the version currently stamped in storage
+    /// - `result_schema_version`: the `SLAResult` schema version this binary expects
+    /// - `config_version_hash`: deterministic hash of the current config snapshot
+    /// - `is_paused`: true when the contract is paused
+    /// - `needs_migration`: true when `storage_version != STORAGE_VERSION`
+    /// - `is_config_frozen`: true when the config is frozen
+    /// - `captured_at`: ledger timestamp when this fingerprint was captured (seconds)
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotInitialized` if the contract has never been initialized (no
+    /// `STORAGE_VERSION_KEY` present). All other contract states return a valid
+    /// fingerprint, including pre-migration and paused states.
+    ///
+    /// # Safety
+    ///
+    /// This function intentionally bypasses `check_version` so it remains callable
+    /// even when the contract is in a pre-migration state (`needs_migration == true`).
+    /// The fingerprint itself reports the migration state, so backends can decide
+    /// whether to proceed or wait for `migrate()` to complete.
+    pub fn get_contract_state_fingerprint(env: Env) -> Result<ContractStateFingerprint, SLAError> {
+        // Read storage version — this is the only field that can cause NotInitialized.
+        let stored_version: u32 = env
+            .storage()
+            .instance()
+            .get(&STORAGE_VERSION_KEY)
+            .ok_or(SLAError::NotInitialized)?;
+
+        // Compute needs_migration without requiring check_version to pass.
+        let needs_migration = stored_version != STORAGE_VERSION;
+
+        // Config version hash computation is safe even in pre-migration state
+        // because load_config works across all initialized states.
+        let config_version_hash = match Self::compute_config_version_hash(&env) {
+            Ok(hash) => hash,
+            Err(_) => 0u64, // If config is unreadable, use sentinel 0
+        };
+
+        // Pause and freeze state default to false if keys are absent.
+        let is_paused: bool = env.storage().instance().get(&PAUSED_KEY).unwrap_or(false);
+        let is_config_frozen: bool = config_freeze::is_config_frozen(&env);
+
+        // Capture the current ledger timestamp.
+        let captured_at = env.ledger().timestamp();
+
+        Ok(ContractStateFingerprint {
+            contract_name: symbol_short!("sla_calc"),
+            storage_version: stored_version,
+            result_schema_version: RESULT_SCHEMA_VERSION,
+            config_version_hash,
+            is_paused,
+            needs_migration,
+            is_config_frozen,
+            captured_at,
+        })
     }
 }

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -7285,3 +7285,212 @@ fn test_historical_parity_golden_results() {
     assert_eq!(schema.schema_version, 1, "Result schema version changed — check migration notes");
     assert_eq!(schema.deprecated_symbols.len(), 0, "Unexpected deprecated symbols in v1");
 }
+
+
+// ============================================================
+// Issue #261 – Contract state fingerprint for release review and upgrade planning
+// ============================================================
+//
+// Acceptance criteria:
+// - The fingerprint includes storage_version, result_schema_version,
+//   config_version_hash, is_paused, needs_migration, is_config_frozen, and captured_at.
+// - The function is callable without auth (read-only).
+// - The function bypasses check_version so it works in a pre-migration state.
+// - The captured_at field contains the ledger timestamp.
+
+#[test]
+fn test_261_fingerprint_includes_all_required_fields() {
+    let (_env, client, _actors) = setup();
+    let fingerprint = client.get_contract_state_fingerprint();
+    
+    assert_eq!(fingerprint.contract_name, symbol_short!("sla_calc"));
+    assert_eq!(fingerprint.storage_version, 1);
+    assert_eq!(fingerprint.result_schema_version, 1);
+    assert!(fingerprint.config_version_hash > 0, "config hash must be non-zero");
+    assert_eq!(fingerprint.is_paused, false);
+    assert_eq!(fingerprint.needs_migration, false);
+    assert_eq!(fingerprint.is_config_frozen, false);
+    // captured_at should be the ledger timestamp (0 in test env by default)
+    assert_eq!(fingerprint.captured_at, 0);
+}
+
+#[test]
+fn test_261_fingerprint_is_deterministic_on_repeated_calls() {
+    let (_env, client, _actors) = setup();
+    let fp1 = client.get_contract_state_fingerprint();
+    let fp2 = client.get_contract_state_fingerprint();
+    
+    assert_eq!(fp1.storage_version, fp2.storage_version);
+    assert_eq!(fp1.result_schema_version, fp2.result_schema_version);
+    assert_eq!(fp1.config_version_hash, fp2.config_version_hash);
+    assert_eq!(fp1.is_paused, fp2.is_paused);
+    assert_eq!(fp1.needs_migration, fp2.needs_migration);
+    assert_eq!(fp1.is_config_frozen, fp2.is_config_frozen);
+}
+
+#[test]
+fn test_261_fingerprint_reflects_paused_state() {
+    let (env, client, actors) = setup();
+    
+    let fp_before = client.get_contract_state_fingerprint();
+    assert_eq!(fp_before.is_paused, false);
+    
+    client.pause(&actors.admin, &soroban_sdk::String::from_str(&env, "maintenance"));
+    
+    let fp_after = client.get_contract_state_fingerprint();
+    assert_eq!(fp_after.is_paused, true);
+}
+
+#[test]
+fn test_261_fingerprint_reflects_config_frozen_state() {
+    let (_env, client, actors) = setup();
+    
+    let fp_before = client.get_contract_state_fingerprint();
+    assert_eq!(fp_before.is_config_frozen, false);
+    
+    client.freeze_config(&actors.admin);
+    
+    let fp_after = client.get_contract_state_fingerprint();
+    assert_eq!(fp_after.is_config_frozen, true);
+}
+
+#[test]
+fn test_261_fingerprint_config_hash_changes_on_config_update() {
+    let (_env, client, actors) = setup();
+    
+    let fp_before = client.get_contract_state_fingerprint();
+    let hash_before = fp_before.config_version_hash;
+    
+    client.set_config(&actors.admin, &symbol_short!("critical"), &20, &200, &1000);
+    
+    let fp_after = client.get_contract_state_fingerprint();
+    let hash_after = fp_after.config_version_hash;
+    
+    assert_ne!(hash_before, hash_after, "config hash must change after config update");
+}
+
+#[test]
+fn test_261_fingerprint_accessible_without_auth() {
+    // The fingerprint function should not require auth — it's a pure read-only view.
+    // This is implicitly tested by all previous tests, but let's be explicit.
+    let (_env, client, _actors) = setup();
+    
+    // No auth required — just call it directly
+    let fingerprint = client.get_contract_state_fingerprint();
+    assert_eq!(fingerprint.contract_name, symbol_short!("sla_calc"));
+}
+
+#[test]
+fn test_261_fingerprint_works_in_pre_migration_state() {
+    // Force the contract into a pre-migration state (version mismatch)
+    // and verify the fingerprint still returns successfully with needs_migration=true.
+    let (env, client, actors) = setup();
+    
+    // Manually write a different storage version to simulate pre-migration
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&symbol_short!("VER"), &0u32);
+    });
+    
+    // The fingerprint must still work (bypasses check_version)
+    let fingerprint = client.get_contract_state_fingerprint();
+    assert_eq!(fingerprint.storage_version, 0);
+    assert_eq!(fingerprint.needs_migration, true);
+}
+
+#[test]
+fn test_261_fingerprint_before_and_after_upgrade_differ() {
+    // Simulate an upgrade workflow: capture fingerprint, trigger migration,
+    // capture again, and verify config_version_hash remained stable but
+    // needs_migration flipped.
+    let (env, client, actors) = setup();
+    
+    // Force version 0 to simulate pre-upgrade state
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&symbol_short!("VER"), &0u32);
+    });
+    
+    let fp_before = client.get_contract_state_fingerprint();
+    assert_eq!(fp_before.storage_version, 0);
+    assert_eq!(fp_before.needs_migration, true);
+    
+    // Migrate
+    client.migrate(&actors.admin);
+    
+    let fp_after = client.get_contract_state_fingerprint();
+    assert_eq!(fp_after.storage_version, 1);
+    assert_eq!(fp_after.needs_migration, false);
+    
+    // Config hash should remain unchanged across migration if no config changed
+    assert_eq!(fp_before.config_version_hash, fp_after.config_version_hash);
+}
+
+#[test]
+fn test_261_fingerprint_use_case_incident_response_audit() {
+    // Use case: during an incident, quickly surface the contract's posture.
+    let (env, client, actors) = setup();
+    
+    // Simulate incident: admin pauses the contract
+    client.pause(&actors.admin, &soroban_sdk::String::from_str(&env, "incident"));
+    
+    // Backend calls fingerprint to check state
+    let fingerprint = client.get_contract_state_fingerprint();
+    
+    assert_eq!(fingerprint.is_paused, true);
+    assert_eq!(fingerprint.is_config_frozen, false);
+    assert_eq!(fingerprint.needs_migration, false);
+    
+    // All critical state visible in one call
+}
+
+#[test]
+fn test_261_fingerprint_use_case_pre_upgrade_audit() {
+    // Use case: before deploying a new contract version, capture the fingerprint
+    // to compare against post-upgrade state.
+    let (_env, client, _actors) = setup();
+    
+    let fp_pre_upgrade = client.get_contract_state_fingerprint();
+    
+    // Verify all expected pre-upgrade state
+    assert_eq!(fp_pre_upgrade.storage_version, 1);
+    assert_eq!(fp_pre_upgrade.needs_migration, false);
+    assert!(fp_pre_upgrade.config_version_hash > 0);
+    
+    // In a real workflow, this fingerprint would be stored and compared
+    // against the post-upgrade fingerprint to verify only expected state changed.
+}
+
+#[test]
+fn test_261_fingerprint_matches_individual_queries() {
+    // Verify the fingerprint fields match what individual queries return.
+    let (_env, client, _actors) = setup();
+    
+    let fingerprint = client.get_contract_state_fingerprint();
+    let version_info = client.get_version_info();
+    let migration_state = client.get_migration_state();
+    let config_hash = client.get_config_version_hash();
+    let is_paused = client.is_paused();
+    let is_frozen = client.is_config_frozen();
+    
+    assert_eq!(fingerprint.storage_version, version_info.storage_version);
+    assert_eq!(fingerprint.result_schema_version, version_info.result_schema_version);
+    assert_eq!(fingerprint.needs_migration, version_info.needs_migration);
+    assert_eq!(fingerprint.storage_version, migration_state.stored_version);
+    assert_eq!(fingerprint.needs_migration, migration_state.needs_migration);
+    assert_eq!(fingerprint.config_version_hash, config_hash);
+    assert_eq!(fingerprint.is_paused, is_paused);
+    assert_eq!(fingerprint.is_config_frozen, is_frozen);
+}
+
+#[test]
+#[should_panic]
+fn test_261_fingerprint_fails_on_uninitialized_contract() {
+    // Before initialize(), the contract has no STORAGE_VERSION_KEY,
+    // so get_contract_state_fingerprint should return NotInitialized.
+    let env = Env::default();
+    env.mock_all_auths();
+    let cid = env.register_contract(None, SLACalculatorContract);
+    let client = SLACalculatorContractClient::new(&env, &cid);
+    
+    // No initialize() called — fingerprint must fail
+    client.get_contract_state_fingerprint();
+}


### PR DESCRIPTION
Resolves #261

## Summary

Introduces get_contract_state_fingerprint() — a compact, deterministic, read-only helper that packages the contract's live state into a single reviewable summary for release review and upgrade planning.

## New Public API

### ContractStateFingerprint struct (lib.rs)

A new #[contracttype] struct that captures:
- contract_name         — fixed label for log correlation
- storage_version       — version stamped in contract storage
- 
esult_schema_version — SLAResult schema version this binary expects
- config_version_hash   — deterministic hash of the current config snapshot
- is_paused             — true when the contract is paused
-
eeds_migration       — true when storage_version != STORAGE_VERSION
- is_config_frozen      — true when set_config is blocked by freeze
- captured_at           — ledger timestamp at the moment of the call (seconds)

### get_contract_state_fingerprint(env: Env) -> Result<ContractStateFingerprint, SLAError>

A new public view function on SLACalculatorContract that:
- Requires **no authentication** (read-only, non-mutating)
- Emits **no events**
- Intentionally **bypasses check_version** so it remains callable even when the contract is in a pre-migration state — the eeds_migration
  field surfaces that condition to the caller
- Returns NotInitialized only when the contract has never been initialized

## Use Cases

1. **Pre/post-upgrade audit**: capture fingerprint before deploying, compare after migration to verify only expected state changed.
2. **Incident response**: surface contract posture in one call without issuing separate queries for version, config hash, pause, freeze states.
3. **Backend health monitoring**: backends can cache the fingerprint and poll it to detect unexpected state drift.

## Tests (tests.rs — 11 new tests)

- 	est_261_fingerprint_includes_all_required_fields — verifies all struct fields are present and have expected post-initialize values
- 	est_261_fingerprint_is_deterministic_on_repeated_calls — same state, same values across multiple reads
- 	est_261_fingerprint_reflects_paused_state — is_paused flips to true after admin pause
- 	est_261_fingerprint_reflects_config_frozen_state — is_config_frozen flips to true after freeze_config
- 	est_261_fingerprint_config_hash_changes_on_config_update — config_version_hash changes when set_config is called
- 	est_261_fingerprint_accessible_without_auth — no auth required
- 	est_261_fingerprint_works_in_pre_migration_state — bypasses check_version, returns needs_migration=true when version is force-set to 0
- 	est_261_fingerprint_before_and_after_upgrade_differ — migration flips needs_migration while config hash stays stable
- 	est_261_fingerprint_use_case_incident_response_audit — incident scenario
- 	est_261_fingerprint_use_case_pre_upgrade_audit — pre-upgrade capture scenario
- 	est_261_fingerprint_matches_individual_queries — all fields match their standalone query equivalents (get_version_info, get_migration_state, etc.)
- 	est_261_fingerprint_fails_on_uninitialized_contract — NotInitialized error on uninitialized contract

## Acceptance Criteria

✅ A new state fingerprint helper exists (get_contract_state_fingerprint) ✅ Its output is deterministic and documented (all fields documented in struct) ✅ It is safe to call on a live contract without mutating state ✅ It bypasses check_version to remain usable in pre-migration states ✅ Tests cover all acceptance scenarios

## Implementation Notes

- Additive and non-breaking: no existing storage keys modified, no existing functions altered, no events added.
- The config_version_hash falls back to 0 if config is unreadable (e.g., in a partial initialization state), ensuring the function never panics.

Closes #261

## Description
Brief description of the changes in this PR.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issues
Fixes #(issue number) or relates to #(issue number)

## Changes Made
- 
- 
- 

## Testing
Describe the testing performed to validate these changes:
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented complex logic
- [ ] I have updated relevant documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] My changes do not introduce new warnings

## Screenshots (if applicable)
Add screenshots or logs if applicable.



closes #261 