### PR TITLE
refactor(sla): establish stable boundary between calculate_sla business logic and event publication

### DIFF
--- a/apexchainx_calculator/src/calculation.rs
+++ b/apexchainx_calculator/src/calculation.rs
@@ -2,6 +2,28 @@
 //!
 //! This module contains the delegated implementation of `calculate_sla`,
 //! `calculate_sla_view`, stats management, and telemetry recording.
+//!
+//! # Boundary between business logic and side effects
+//!
+//! The computation pipeline enforces a strict separation:
+//!
+//! | Phase | What happens | Side effects? |
+//! |---|---|---|
+//! | **1. Pre-flight** | Version check, pause check, operator auth, config load | Read-only |
+//! | **2. Pure computation** | `compute_result()` — deterministic SLA outcome from inputs | None |
+//! | **3. State mutation** | History anti-spam, telemetry recording, stats increment | Storage writes only |
+//! | **4. Event publication** | `publish_sla_event()` + `publish_settlement_intent_event()` | Event emission |
+//!
+//! This separation ensures:
+//! - `compute_result()` can be called by `calculate_sla_view` (read-only audit)
+//!   without touching storage or emitting events.
+//! - Event schemas can evolve independently of the computation rules.
+//! - Tests can validate business logic without needing an event assertion harness
+//!   by calling `compute_result()` directly.
+//! - The same outcome is deterministic regardless of whether events are
+//!   actually published (e.g. in dry-run simulations).
+//!
+//! See [`crate::event::EventPublisher`] for the event publication abstraction.
 
 use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 
@@ -17,6 +39,17 @@ use crate::{
 /// See [`crate::SLACalculatorContract::calculate_sla`] for the full API
 /// contract and [`crate::SLAError::DuplicateOutageInput`] for the
 /// duplicate-detection semantics.
+///
+/// # Execution phases
+///
+/// This function follows a strict phased execution model:
+/// 1. **Pre-flight** — version check, pause guard, operator authorization, config load.
+/// 2. **Pure computation** — `compute_result()` produces a deterministic outcome.
+/// 3. **State mutation** — anti-spam dedup, history append, telemetry, stats update.
+/// 4. **Event publication** — `publish_sla_event()` + `publish_settlement_intent_event()`.
+///
+/// Phases 1-3 constitute the **business logic** boundary. Phase 4 is the sole
+/// **side-effect** phase and never alters the returned `SLAResult`.
 pub fn calculate_sla(
     env: &Env,
     caller: &Address,
@@ -24,12 +57,15 @@ pub fn calculate_sla(
     severity: Symbol,
     mttr_minutes: u32,
 ) -> Result<SLAResult, SLAError> {
+    // ── Phase 1: Pre-flight (read-only auth & config) ──────────────────
     crate::SLACalculatorContract::check_version(env)?;
     require_not_paused(env)?;
     crate::SLACalculatorContract::require_operator(env, caller)?;
 
     let cfg = crate::SLACalculatorContract::load_config(env, &severity)?;
     let config_version_hash = crate::SLACalculatorContract::compute_config_version_hash(env)?;
+
+    // ── Phase 2: Pure computation (no state reads/writes) ─────────────
     let result = compute_result(
         outage_id.clone(),
         mttr_minutes,
@@ -37,6 +73,8 @@ pub fn calculate_sla(
         config_version_hash,
         env.ledger().timestamp(),
     )?;
+
+    // ── Phase 3: State mutation (storage writes only) ─────────────────
     let mut history: Vec<SLAResult> = env
         .storage()
         .instance()
@@ -95,6 +133,10 @@ pub fn calculate_sla(
         increment_stats(env, true, result.amount, 0);
     }
 
+    // ── Phase 4: Event publication (side effects only) ────────────────
+    // Published after all state mutations are committed so that indexers
+    // observe a consistent view. These calls never affect the returned
+    // SLAResult and can be toggled independently for dry-run modes.
     publish_sla_event(env, severity.clone(), &result);
     publish_settlement_intent_event(env, severity, &result);
 

--- a/apexchainx_calculator/src/event.rs
+++ b/apexchainx_calculator/src/event.rs
@@ -1,18 +1,46 @@
 use soroban_sdk::{contracttype, Env, Symbol};
 
+/// Structured event payload for calculation execution events.
+///
+/// This struct is the canonical event shape emitted when a business-logic
+/// calculation completes. It is defined here rather than in `calculation.rs`
+/// so that the event schema and the computation logic can evolve independently.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CalculationExecutedEventV1 {
+    /// Input key associated with the calculation (e.g. outage_id).
     pub input_key: Symbol,
+    /// Input value for the calculation.
     pub input_value: i128,
+    /// Computed result value.
     pub result_value: i128,
+    /// Ledger timestamp at calculation time.
     pub timestamp: u64,
 }
 
+/// A stateless event publisher that owns no state and only emits events.
+///
+/// # Boundary between business logic and side effects
+///
+/// `EventPublisher` is intentionally decoupled from computation functions
+/// like [`crate::calculation::compute_result`]. The business logic returns
+/// a pure result, and callers (e.g. `calculate_sla`) decide whether and
+/// when to publish events. This separation:
+///
+/// - Makes business logic testable without needing an event assertion harness.
+/// - Keeps event schemas versioned independently from computation rules.
+/// - Allows the same computation to be used in view-only (`calculate_sla_view`)
+///   and mutating (`calculate_sla`) paths without conditional event logic.
+///
+/// Events are always published through this struct to ensure consistent
+/// topic layout and payload formatting.
 pub struct EventPublisher;
 
 impl EventPublisher {
-    /// Publishes calculation execution event while preserving strict field ordering
+    /// Publishes a calculation execution event with strict field ordering.
+    ///
+    /// Topic layout: `(topic, input_key)` for efficient filtering.
+    /// Payload: `CalculationExecutedEventV1` with all fields in canonical order.
     pub fn publish_calculation_executed(
         env: &Env,
         topic: Symbol,
@@ -27,41 +55,7 @@ impl EventPublisher {
             result_value,
             timestamp,
         };
-        
-        env.events().publish((topic, input_key), payload);
-    }
-}
 
-use soroban_sdk::{contracttype, Env, Symbol};
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CalculationExecutedEventV1 {
-    pub input_key: Symbol,
-    pub input_value: i128,
-    pub result_value: i128,
-    pub timestamp: u64,
-}
-
-pub struct EventPublisher;
-
-impl EventPublisher {
-    /// Publishes calculation execution event while preserving strict field ordering
-    pub fn publish_calculation_executed(
-        env: &Env,
-        topic: Symbol,
-        input_key: Symbol,
-        input_value: i128,
-        result_value: i128,
-        timestamp: u64,
-    ) {
-        let payload = CalculationExecutedEventV1 {
-            input_key,
-            input_value,
-            result_value,
-            timestamp,
-        };
-        
         env.events().publish((topic, input_key), payload);
     }
 }


### PR DESCRIPTION
## Overview

Establishes a documented, stable boundary between SLA computation (business logic) and event publication (side effects) in the `calculate_sla` function. Also fixes duplicate code in `event.rs`.

## Related Issue

Closes #259

## Changes

### 🧹 Code Cleanup
- **[FIX]** `apexchainx_calculator/src/event.rs` — removed duplicate `CalculationExecutedEventV1` struct and `EventPublisher` impl (both were defined twice)

### 📐 Boundary Documentation
- **[DOCS]** `apexchainx_calculator/src/calculation.rs` — added comprehensive module-level documentation describing the four-phase execution model:

  | Phase | What happens | Side effects? |
  |---|---|---|
  | 1. Pre-flight | Version check, pause check, operator auth, config load | Read-only |
  | 2. Pure computation | `compute_result()` — deterministic SLA outcome from inputs | None |
  | 3. State mutation | History anti-spam, telemetry recording, stats increment | Storage writes only |
  | 4. Event publication | `publish_sla_event()` + `publish_settlement_intent_event()` | Event emission |

- **[DOCS]** Annotated `calculate_sla` with inline phase markers (1-4) making the boundary between business logic and side effects explicit in the code itself
- **[DOCS]** `event.rs` — Added documentation to `EventPublisher` struct explaining why it is decoupled from computation functions

### Why This Matters
- `compute_result()` can be called by `calculate_sla_view` (read-only audit) without touching storage or emitting events
- Event schemas can evolve independently of computation rules
- Tests can validate business logic without needing an event assertion harness
- The same outcome is deterministic regardless of whether events are published

## Verification

- No functional changes — all existing tests continue to pass
- The refactor is purely additive (documentation and code organization)
- `compute_result()` remains the pure, side-effect-free core
- Event publication remains deterministic and versioned

## Acceptance Criteria

| Criteria | Status |
|---|---|
| Contract logic is clearer to reason about | ✅ Four-phase execution model documented and annotated in code |
| Event publication remains deterministic and versioned | ✅ No changes to event schema or publication logic |
| Tests continue to validate both the result and emitted events | ✅ All existing tests in tests.rs cover events |