### PR TITLE
test(#387): verify severity telemetry counters saturate at u32::MAX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   internal severity list invariant is ever broken the call surfaces a
   deterministic `InvalidSeverity` error rather than an unrecoverable host trap.
 ### Added
+- Per-severity telemetry counter saturation regression coverage — documented the `u32` lane saturation behavior in the `record_severity_telemetry` code docs and `docs/CONTRACT_MAINTENANCE_POLICY.md`, and added `test_severity_telemetry_counters_saturate_at_u32_max` to verify counters saturate at `u32::MAX` instead of wrapping (release) or panicking (debug) (#387)
 - `docs/CONTRACT_SHAPE_CHANGE_CHECKLIST.md` — release-readiness checklist for PRs that touch storage keys, `STORAGE_VERSION`, event topic constants, or event payload fields; cross-referenced from `CONTRIBUTING.md` as SC-100
 - **[SC-509] SLAError Addition Workflow** (#253) — comprehensive contributor guide for adding, deprecating, or reviewing `SLAError` variants without breaking backend adapter logic. See `docs/sla-error-additions-guide.md`.
 - `error_responses::is_severity_not_in_set` — typed helper predicate for `SLAError::SeverityNotInSet` (#253)

--- a/apexchainx_calculator/src/calculation.rs
+++ b/apexchainx_calculator/src/calculation.rs
@@ -305,6 +305,11 @@ fn set_count_lane(packed: u128, index: u32, value: u32) -> u128 {
 /// - **Lane Isolation**: Reset is per-severity lane. Calculations or inactivity in one severity level do not reset telemetry for other severities.
 /// - **Reinitialization**: Upon reset, the lane's calculation and violation counters are cleared to 0 before the current invocation is recorded,
 ///   reinitializing the count to 1 calculation (and 1 violation if the current calculation violated SLA).
+///
+/// ### Counter Saturation
+/// Each severity lane is a `u32`. Increments use `saturating_add(1)`, so a lane
+/// saturates at `u32::MAX` rather than wrapping (release) or panicking (debug).
+/// `u32::MAX` is treated as "many" and is never reset to zero by overflow.
 pub fn record_severity_telemetry(env: &Env, severity: &Symbol, met: bool) {
     let index = crate::SLACalculatorContract::canonical_severity_index(severity).unwrap_or(0);
     let mut calculations = load_counts(env, &SEVERITY_CALC_COUNTS_KEY);

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -2805,6 +2805,12 @@ impl SLACalculatorContract {
         );
     }
 
+    /// Records per-severity calculation/violation counters for telemetry.
+    ///
+    /// Each severity lane is a `u32`. Counters are incremented with
+    /// `saturating_add(1)`, so they saturate at `u32::MAX` instead of wrapping
+    /// (release) or panicking (debug). A saturated lane is treated as "many"
+    /// and is never reset to zero by overflow.
     fn record_severity_telemetry(env: &Env, severity: &Symbol, met: bool) {
         let index = Self::canonical_severity_index(severity).unwrap_or(0);
         let mut calculations = Self::load_counts(env, &SEVERITY_CALC_COUNTS_KEY);

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -304,6 +304,36 @@ fn test_severity_telemetry_weekly_reset_semantics() {
     assert_eq!(high4.violation_rate, 100);
 }
 
+#[test]
+fn test_severity_telemetry_counters_saturate_at_u32_max() {
+    let (env, client, actors) = setup();
+    env.ledger().set_timestamp(1000);
+
+    // Seed the critical lane (index 0) of both per-severity counters at u32::MAX.
+    let lane_max = u32::MAX as u128;
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&SEVERITY_CALC_COUNTS_KEY, &lane_max);
+        env.storage().instance().set(&SEVERITY_VIOL_COUNTS_KEY, &lane_max);
+    });
+
+    // A violation (20 > 15-minute critical threshold) increments both counters.
+    client.calculate_sla(
+        &actors.operator,
+        &symbol_short!("EVTSAT"),
+        &symbol_short!("critical"),
+        &20,
+    );
+
+    // Incrementing past u32::MAX must saturate (stay at u32::MAX), not wrap.
+    env.as_contract(&client.address, || {
+        let calculations: u128 = env.storage().instance().get(&SEVERITY_CALC_COUNTS_KEY).unwrap();
+        let violations: u128 = env.storage().instance().get(&SEVERITY_VIOL_COUNTS_KEY).unwrap();
+
+        assert_eq!((calculations & 0xFFFF_FFFF) as u32, u32::MAX);
+        assert_eq!((violations & 0xFFFF_FFFF) as u32, u32::MAX);
+    });
+}
+
 // ============================================================
 // #28 – Operator management
 // ============================================================

--- a/docs/CONTRACT_MAINTENANCE_POLICY.md
+++ b/docs/CONTRACT_MAINTENANCE_POLICY.md
@@ -340,6 +340,10 @@ or violation ledger entry.
 - **Reset is explicit** — counters are set to zero when the window advances
 - **Last calculation/violation ledger** snapshots are stored per severity
   to determine when a reset is needed
+- **Saturation is explicit** — each severity lane is a `u32` and is incremented
+  with `saturating_add(1)`, so a lane saturates at `u32::MAX` instead of
+  wrapping (release) or panicking (debug). `u32::MAX` means "many" and is never
+  reset to zero by overflow.
 - **Backends should not rely on exact counter values** across window boundaries;
   use the `SeverityTelemetry` view for consistent reads
 


### PR DESCRIPTION
## Description

The per-severity telemetry counters (`SEVERITY_CALC_COUNTS_KEY`, `SEVERITY_VIOL_COUNTS_KEY`) already increment their `u32` lanes with `saturating_add(1)`, so they saturate at `u32::MAX` rather than wrapping (release) or panicking (debug). This PR completes the remaining acceptance criteria for #387 by adding regression coverage and documenting the saturation behavior.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Related Issues
Fixes #387

## Changes Made
- Added `test_severity_telemetry_counters_saturate_at_u32_max`: seeds a severity lane at `u32::MAX` and asserts the counter stays at `u32::MAX` after a violation (no wrap, no panic).
- Documented `u32` lane saturation in `record_severity_telemetry` (`calculation.rs` and `lib.rs`).
- Documented the saturation behavior in `docs/CONTRACT_MAINTENANCE_POLICY.md` (SC-507 "Per-Severity Weekly Telemetry").
- Added a `CHANGELOG.md` entry under `[Unreleased] -> Added`.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Verification run locally:
- `cargo test --lib test_severity_telemetry` -> 3/3 passed
- `cargo test --lib` (full suite) -> 563 passed, 0 failed, 5 ignored
- `cargo fmt --check` -> clean
- `cargo clippy --all-targets -- -D warnings` -> clean

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented complex logic
- [x] I have updated relevant documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes do not introduce new warnings
