### PR TITLE
feat(sla): emit dup_input event with stored result on duplicate rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   internal severity list invariant is ever broken the call surfaces a
   deterministic `InvalidSeverity` error rather than an unrecoverable host trap.
 ### Added
+- `dup_input` event — emitted on the `DuplicateOutageInput` rejection path carrying the previously stored `SLAResult`, so consumers can reconcile a conflicting duplicate from the same transaction's event log without a follow-up `get_latest_by_outage` call (closes #385)
 - Per-severity telemetry counter saturation regression coverage — documented the `u32` lane saturation behavior in the `record_severity_telemetry` code docs and `docs/CONTRACT_MAINTENANCE_POLICY.md`, and added `test_severity_telemetry_counters_saturate_at_u32_max` to verify counters saturate at `u32::MAX` instead of wrapping (release) or panicking (debug) (#387)
 - `docs/CONTRACT_SHAPE_CHANGE_CHECKLIST.md` — release-readiness checklist for PRs that touch storage keys, `STORAGE_VERSION`, event topic constants, or event payload fields; cross-referenced from `CONTRIBUTING.md` as SC-100
 - **[SC-509] SLAError Addition Workflow** (#253) — comprehensive contributor guide for adding, deprecating, or reviewing `SLAError` variants without breaking backend adapter logic. See `docs/sla-error-additions-guide.md`.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ address may call them.
 
 | Method | What it writes |
 |--------|----------------|
-| `calculate_sla` | Appends a result to history, updates cumulative stats and per-severity telemetry, emits `sla_calc` and `set_int` events. Idempotent on exact replay; rejects conflicting duplicates. |
+| `calculate_sla` | Appends a result to history, updates cumulative stats and per-severity telemetry, emits `sla_calc` and `set_int` events. Idempotent on exact replay; rejects conflicting duplicates with a `dup_input` event carrying the stored result. |
 
 ### Privileged — admin role
 

--- a/apexchainx_calculator/src/api_stability.rs
+++ b/apexchainx_calculator/src/api_stability.rs
@@ -100,10 +100,24 @@ pub fn sl_a_error_count() -> u32 {
 
 /// Returns the list of event name symbols that form the public event ABI.
 /// Backend listeners depend on these names never changing.
-pub fn event_name_symbols() -> [&'static str; 15] {
+pub fn event_name_symbols() -> [&'static str; 16] {
     [
-        "sla_calc", "set_int", "cfg_upd", "paused", "unpause", "op_set", "pruned", "pruned_a", "adm_prop",
-        "adm_acc", "adm_can", "adm_ren", "op_prop", "op_acc", "op_can",
+        "sla_calc",
+        "set_int",
+        "cfg_upd",
+        "paused",
+        "unpause",
+        "op_set",
+        "pruned",
+        "pruned_a",
+        "adm_prop",
+        "adm_acc",
+        "adm_can",
+        "adm_ren",
+        "op_prop",
+        "op_acc",
+        "op_can",
+        "dup_input",
     ]
 }
 
@@ -128,7 +142,7 @@ pub fn assess_stability() -> StabilityScore {
     }
 
     // Check event symbols are at expected count.
-    if event_name_symbols().len() != 15 {
+    if event_name_symbols().len() != 16 {
         return StabilityScore::C;
     }
 
@@ -188,7 +202,7 @@ mod tests {
     fn test_225_event_symbols_are_well_known() {
         // All public event names must be documented and stable.
         let events = event_name_symbols();
-        let expected = 15;
+        let expected = 16;
         assert_eq!(
             events.len(),
             expected,

--- a/apexchainx_calculator/src/calculation.rs
+++ b/apexchainx_calculator/src/calculation.rs
@@ -28,9 +28,9 @@
 use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 
 use crate::{
-    SLAConfig, SLAError, SLAResult, SLAStats, SeverityTelemetry, EVENT_SETTLE_INTENT, EVENT_SLA_CALC,
-    EVENT_VERSION, HISTORY_KEY, LAST_CALCULATION_LEDGER_KEY, LAST_VIOLATION_LEDGER_KEY, MAX_HISTORY_SIZE,
-    MAX_RECALCS_PER_OUTAGE, PAUSED_KEY, RETENTION_LIMIT_KEY, SEVERITY_CALC_COUNTS_KEY,
+    SLAConfig, SLAError, SLAResult, SLAStats, SeverityTelemetry, EVENT_DUP_INPUT, EVENT_SETTLE_INTENT,
+    EVENT_SLA_CALC, EVENT_VERSION, HISTORY_KEY, LAST_CALCULATION_LEDGER_KEY, LAST_VIOLATION_LEDGER_KEY,
+    MAX_HISTORY_SIZE, MAX_RECALCS_PER_OUTAGE, PAUSED_KEY, RETENTION_LIMIT_KEY, SEVERITY_CALC_COUNTS_KEY,
     SEVERITY_VIOL_COUNTS_KEY, STATS_KEY,
 };
 
@@ -94,6 +94,10 @@ pub fn calculate_sla(
     if let Some(prev) = existing {
         if prev.config_version_hash == config_version_hash {
             if prev.mttr_minutes != mttr_minutes || prev.threshold_minutes != cfg.threshold_minutes {
+                // #385 – publish the stored result alongside the rejection so
+                // consumers can reconcile the conflict from this transaction's
+                // event log without a second get_latest_by_outage read.
+                publish_duplicate_input_event(env, severity.clone(), &prev);
                 return Err(SLAError::DuplicateOutageInput);
             }
             // Replay: return the stored decision without touching state.
@@ -438,6 +442,23 @@ fn publish_settlement_intent_event(env: &Env, severity: Symbol, result: &SLAResu
             result.amount,
             result.config_version_hash,
             result.recorded_at,
+        ),
+    );
+}
+
+fn publish_duplicate_input_event(env: &Env, severity: Symbol, existing: &SLAResult) {
+    env.events().publish(
+        (EVENT_DUP_INPUT, EVENT_VERSION, severity),
+        (
+            existing.outage_id.clone(),
+            existing.status.clone(),
+            existing.mttr_minutes,
+            existing.threshold_minutes,
+            existing.amount,
+            existing.payment_type.clone(),
+            existing.rating.clone(),
+            existing.config_version_hash,
+            existing.recorded_at,
         ),
     );
 }

--- a/apexchainx_calculator/src/event_schema.rs
+++ b/apexchainx_calculator/src/event_schema.rs
@@ -26,6 +26,16 @@
 //! - payload:  (outage_id: Symbol, status: Symbol, payment_type: Symbol,
 //!   amount: i128, config_version_hash: u64, recorded_at: u64)
 //!
+//! ## dup_input (`dup_input`)
+//! Emitted when `calculate_sla` rejects a conflicting duplicate `outage_id`
+//! (the `DuplicateOutageInput` error path). Carries the previously stored
+//! `SLAResult` so consumers can reconcile the rejection without a separate
+//! `get_latest_by_outage` read. (#385)
+//! - topic[2]: severity Symbol
+//! - payload:  (outage_id: Symbol, status: Symbol, mttr_minutes: u32,
+//!   threshold_minutes: u32, amount: i128, payment_type: Symbol,
+//!   rating: Symbol, config_version_hash: u64, recorded_at: u64)
+//!
 //! ## cfg_upd (`cfg_upd`)
 //! Emitted on every successful `set_config` call.
 //! - topic[2]: severity Symbol
@@ -199,6 +209,8 @@ pub const EVENT_CONFIG_FREEZE: Symbol = symbol_short!("cfg_frz");
 pub const EVENT_CONFIG_UNFREEZE: Symbol = symbol_short!("cfg_unfrz");
 /// Emitted when a running-stats counter saturates. (SC-W5-047)
 pub const EVENT_STATS_SAT: Symbol = symbol_short!("stats_sat");
+/// Emitted on the `DuplicateOutageInput` error path with the stored result. (#385)
+pub const EVENT_DUP_INPUT: Symbol = symbol_short!("dup_input");
 pub const EVENT_MIGRATE_DONE: &str = "migrate_done";
 
 /// Returns the canonical event version string for consumer documentation.
@@ -237,6 +249,7 @@ mod tests {
             EVENT_CONFIG_FREEZE,
             EVENT_CONFIG_UNFREEZE,
             EVENT_STATS_SAT,
+            EVENT_DUP_INPUT,
         ];
 
         for i in 0..names.len() {

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -257,6 +257,11 @@ pub use crate::config_metadata::LAST_CFG_UPDATE_KEY;
 //              amount: i128, config_version_hash: u64, recorded_at: u64)
 //   context: severity Symbol
 //
+// dup_input → (outage_id: Symbol, status: Symbol, mttr_minutes: u32,
+//              threshold_minutes: u32, amount: i128, payment_type: Symbol,
+//              rating: Symbol, config_version_hash: u64, recorded_at: u64)
+//   context: severity Symbol
+//
 // stats_sat → (field: Symbol, previous_value: i128, attempted_increment: i128)
 //   context: counter_name Symbol
 // -----------------------------------------------------------------------
@@ -378,6 +383,17 @@ pub(crate) const EVENT_CONFIG_UNFREEZE: Symbol = symbol_short!("cfg_unfrz");
 /// without a version bump, as backend alerting pipelines parse this shape.
 pub(crate) const EVENT_STATS_SAT: Symbol = symbol_short!("stats_sat");
 
+/// Emitted when `calculate_sla` rejects a conflicting duplicate `outage_id`
+/// under an unchanged config version hash (the `DuplicateOutageInput` error
+/// path). Carries the previously stored `SLAResult` so consumers can reconcile
+/// the rejection without a separate `get_latest_by_outage` read. (#385)
+///
+/// Compatibility decision: payload mirrors the full `SLAResult` field order
+/// (outage_id, status, mttr_minutes, threshold_minutes, amount, payment_type,
+/// rating, config_version_hash, recorded_at). Field additions go at the end;
+/// reordering, removal, or type changes require a version bump.
+pub(crate) const EVENT_DUP_INPUT: Symbol = symbol_short!("dup_input");
+
 /// Canonical event version symbol used by all events.
 pub(crate) const EVENT_VERSION: Symbol = symbol_short!("v1");
 
@@ -454,6 +470,11 @@ pub enum SLAError {
     /// 3. If the intent is genuinely to re-evaluate the same outage under
     ///    the same config with different MTTR, the outage must receive a
     ///    new unique `outage_id`.
+    ///
+    /// The contract accompanies this error with a `dup_input` event
+    /// (`EVENT_DUP_INPUT`) carrying the previously stored `SLAResult`, so
+    /// consumers can read the conflicting result from the same transaction's
+    /// event log instead of issuing a follow-up `get_latest_by_outage` call.
     DuplicateOutageInput = 13,
     /// Computed penalty amount is invalid (e.g., overflowed to zero). (SC-W5-046)
     InvalidPenaltyAmount = 14,
@@ -2154,7 +2175,7 @@ impl SLACalculatorContract {
     /// | `ContractPaused` | Contract is currently paused |
     /// | `Unauthorized` | Caller is not the operator |
     /// | `ConfigNotFound` | No configuration exists for the requested severity |
-    /// | `DuplicateOutageInput` | Same `outage_id` submitted with conflicting inputs (see error docs) |
+    /// | `DuplicateOutageInput` | Same `outage_id` submitted with conflicting inputs; emits a `dup_input` event carrying the stored result |
     /// | `InvalidPenaltyAmount` | Penalty computation overflowed or produced a non-negative value |
     /// | `InvalidRewardAmount` | Reward computation overflowed or produced a non-positive value |
     /// Records an SLA decision for `outage_id`. Operator only.
@@ -2169,7 +2190,9 @@ impl SLACalculatorContract {
     ///    therefore free of state drift, however many times it is repeated.
     /// 2. **Conflict** — an unchanged config hash with a different MTTR or
     ///    threshold is rejected with `DuplicateOutageInput`, so a stored decision
-    ///    can never be silently restated.
+    ///    can never be silently restated. The rejection is accompanied by a
+    ///    `dup_input` event carrying the stored result, so consumers need no
+    ///    follow-up `get_latest_by_outage` read.
     /// 3. **Recalculation** — a changed config hash opens a new generation for the
     ///    outage, capped at `MAX_RECALCS_PER_OUTAGE` retained entries. Beyond that
     ///    the call is rejected with `OutageRecalcLimit`, bounding how much of the
@@ -2220,6 +2243,10 @@ impl SLACalculatorContract {
                 // Explicit duplicate policy: same outage_id is idempotent only when
                 // execution inputs resolve to the same deterministic result.
                 if prev.mttr_minutes != mttr_minutes || prev.threshold_minutes != cfg.threshold_minutes {
+                    // #385 – publish the stored result alongside the rejection so
+                    // consumers can reconcile the conflict from this transaction's
+                    // event log without a second get_latest_by_outage read.
+                    Self::publish_duplicate_input_event(&env, severity.clone(), &prev);
                     return Err(SLAError::DuplicateOutageInput);
                 }
                 // Replay: return the stored decision without touching state.
@@ -2837,6 +2864,23 @@ impl SLACalculatorContract {
                 result.amount,
                 result.config_version_hash,
                 result.recorded_at,
+            ),
+        );
+    }
+
+    fn publish_duplicate_input_event(env: &Env, severity: Symbol, existing: &SLAResult) {
+        env.events().publish(
+            (EVENT_DUP_INPUT, EVENT_VERSION, severity),
+            (
+                existing.outage_id.clone(),
+                existing.status.clone(),
+                existing.mttr_minutes,
+                existing.threshold_minutes,
+                existing.amount,
+                existing.payment_type.clone(),
+                existing.rating.clone(),
+                existing.config_version_hash,
+                existing.recorded_at,
             ),
         );
     }

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -6429,6 +6429,84 @@ fn test_255_duplicate_outage_id_with_different_mttr_panics() {
     );
 }
 
+// ============================================================
+// #385 – DuplicateOutageInput rejection carries the stored result
+// ============================================================
+//
+// Soroban contract errors (`#[contracterror]`) are unit-only u32 codes — they
+// cannot carry a payload. To satisfy "the existing result is retrievable from
+// the rejection itself", `calculate_sla` emits a `dup_input` event with the
+// full stored `SLAResult` immediately before returning the
+// `DuplicateOutageInput` error. Consumers read that event from the same
+// transaction instead of issuing a follow-up `get_latest_by_outage` call.
+
+#[test]
+fn test_385_conflicting_duplicate_emits_dup_input_with_stored_result() {
+    let (env, client, actors) = setup();
+    let outage_id = symbol_short!("DUP_EVT");
+    let severity = symbol_short!("high");
+
+    // First submission stores a result.
+    let stored = client.calculate_sla(&actors.operator, &outage_id, &severity, &10u32);
+
+    // Conflicting resubmission is rejected with DuplicateOutageInput.
+    let conflict_err = client
+        .try_calculate_sla(&actors.operator, &outage_id, &severity, &20u32)
+        .unwrap_err()
+        .unwrap();
+    assert!(error_responses::is_duplicate_outage_input(&conflict_err));
+
+    // The rejection must have emitted a dup_input event carrying the stored result.
+    let events = env.events().all();
+    let mut found = false;
+    for i in 0..events.len() {
+        let (_, topics, data) = events.get(i).unwrap();
+        let topic_0: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+        if topic_0 != EVENT_DUP_INPUT {
+            continue;
+        }
+        found = true;
+
+        let topic_1: Symbol = topics.get(1).unwrap().try_into_val(&env).unwrap();
+        let topic_2: Symbol = topics.get(2).unwrap().try_into_val(&env).unwrap();
+        assert_eq!(topic_1, EVENT_VERSION);
+        assert_eq!(topic_2, severity);
+
+        let payload: (Symbol, Symbol, u32, u32, i128, Symbol, Symbol, u64, u64) =
+            data.try_into_val(&env).unwrap();
+        assert_eq!(payload.0, outage_id);
+        assert_eq!(payload.1, stored.status);
+        assert_eq!(payload.2, stored.mttr_minutes);
+        assert_eq!(payload.3, stored.threshold_minutes);
+        assert_eq!(payload.4, stored.amount);
+        assert_eq!(payload.5, stored.payment_type);
+        assert_eq!(payload.6, stored.rating);
+        assert_eq!(payload.7, stored.config_version_hash);
+        assert_eq!(payload.8, stored.recorded_at);
+    }
+    assert!(found, "expected a dup_input event carrying the stored result");
+}
+
+#[test]
+fn test_385_exact_replay_does_not_emit_dup_input() {
+    let (env, client, actors) = setup();
+    let outage_id = symbol_short!("REPLAY_EV");
+    let severity = symbol_short!("high");
+
+    client.calculate_sla(&actors.operator, &outage_id, &severity, &10u32);
+
+    // Idempotent replay returns the stored result without emitting dup_input.
+    let replayed = client.calculate_sla(&actors.operator, &outage_id, &severity, &10u32);
+    assert_eq!(replayed.status, symbol_short!("met"));
+
+    let events = env.events().all();
+    for i in 0..events.len() {
+        let (_, topics, _) = events.get(i).unwrap();
+        let topic_0: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+        assert_ne!(topic_0, EVENT_DUP_INPUT, "exact replay must not emit dup_input");
+    }
+}
+
 #[test]
 fn test_config_bumped_duplicate_treated_as_fresh_calculation() {
     // After set_config changes the config_version_hash, a duplicate outage_id

--- a/docs/FAILURE_TAXONOMY.md
+++ b/docs/FAILURE_TAXONOMY.md
@@ -252,8 +252,9 @@
 | **Recovery** | Correct the input or wait for a config change |
 | **Consumer Impact** | The SLA calculation is rejected because the same `outage_id` was previously submitted with different inputs under the same configuration. |
 | **Emitted By** | `calculate_sla` |
+| **Event** | `dup_input` — emitted with the stored `SLAResult` before the error is returned |
 | **Recovery Strategy** | 1. Check whether the submitted `mttr_minutes` or severity level was entered incorrectly. 2. If the previous calculation was incorrect, admin must call `prune_history()` to remove the conflicting entry. 3. Alternatively, wait for a config update (changes the version hash and allows a fresh entry). 4. If the intent is genuinely a re-evaluation with different data under the same config, use a new unique `outage_id`. |
-| **Runbook** | 1. Call `get_history_by_outage(outage_id)` to inspect the conflicting entry. 2. If the previous entry is erroneous, admin calls `prune_history()`. 3. Re-submit with corrected data. |
+| **Runbook** | 1. Read the `dup_input` event from the rejected transaction to obtain the stored `SLAResult` (no follow-up `get_latest_by_outage` call is required). 2. If the previous entry is erroneous, admin calls `prune_history()`. 3. Re-submit with corrected data. |
 
 ---
 
@@ -326,7 +327,9 @@ def handle_calculate_sla(outage_id, severity, mttr):
             logger.warning(f"Contract paused: {pause_info.reason}")
             return retry_after_unpause()
         elif code == 13:  # DuplicateOutageInput
-            existing = contract.get_latest_by_outage(outage_id)
+            # The rejection transaction emitted a dup_input event carrying the
+            # stored result, so no follow-up contract read is required.
+            existing = extract_dup_input_event(transaction.events, outage_id)
             logger.warning(f"Duplicate outage {outage_id}: {existing}")
             return existing  # Return the previously stored result
         elif code == 19:  # OutageRecalcLimit

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -76,7 +76,7 @@ these.
 
 | Method | What it writes |
 |--------|----------------|
-| `calculate_sla` | Appends a result to history, updates cumulative stats and per-severity telemetry, emits `sla_calc` and `set_int` events. Idempotent on exact replay; rejects conflicting duplicates. |
+| `calculate_sla` | Appends a result to history, updates cumulative stats and per-severity telemetry, emits `sla_calc` and `set_int` events. Idempotent on exact replay; rejects conflicting duplicates with a `dup_input` event carrying the stored result. |
 
 ### Privileged — admin role
 

--- a/docs/RESULT_PAYLOAD_HASHING.md
+++ b/docs/RESULT_PAYLOAD_HASHING.md
@@ -167,12 +167,12 @@ The contract's idempotency policy for `calculate_sla`:
 
 - **Same inputs, same config** → Returns the original result (idempotent, no state change)
 - **Same inputs, different config** → New calculation replaces old entry
-- **Same outage_id, different inputs** → Returns `DuplicateOutageInput` error
+- **Same outage_id, different inputs** → Returns `DuplicateOutageInput` error and emits a `dup_input` event carrying the stored result
 
 ### 5.2 Backend Expectations
 
 - Backends should **deduplicate by `outage_id`** in their event streams
-- When a `DuplicateOutageInput` error is received, the backend should compare the existing result against the attempted submission
+- When a `DuplicateOutageInput` error is received, the backend should read the `dup_input` event from the rejected transaction to obtain the stored result and compare it against the attempted submission (no follow-up `get_latest_by_outage` call is required)
 - The `config_version_hash` is the key discriminator for determining whether a re-submission is truly a duplicate or a legitimate re-evaluation
 
 ---


### PR DESCRIPTION
## Summary

Closes #385.

When `calculate_sla` is called with the same `outage_id` and unchanged `config_version_hash` but **conflicting inputs**, the contract previously returned a bare `SLAError::DuplicateOutageInput` with no way to recover the already-stored result. Callers had to issue a second `get_latest_by_outage` read.

## Key finding & approach

The issue's proposed design — attaching the `SLAResult` to the error variant — is not implementable in Soroban: `#[contracterror]` enums are **unit-only u32 codes**. The macro generates `match` arms that reference each variant by name with no field binding, and the wire format is a bare code (verified against `soroban-sdk-macros` 21.7.7 source).

The idiomatic, non-breaking fix is to emit a diagnostic **`dup_input` event** carrying the full stored `SLAResult` immediately before returning the error. Because the error is a returned value (not a host trap), the event is persisted in the same transaction's event log, so consumers recover the conflicting result without a follow-up contract read.

## Changes

- **`apexchainx_calculator/src/lib.rs`** — new `EVENT_DUP_INPUT` constant; `calculate_sla` emits the event (via a `publish_duplicate_input_event` helper) on the conflict path; docs updated on the error variant and method.
- **`apexchainx_calculator/src/calculation.rs`** — mirrored in the delegated implementation for consistency.
- **`apexchainx_calculator/src/event_schema.rs`** — registered `dup_input` in the catalog + distinctness test.
- **`apexchainx_calculator/src/api_stability.rs`** — added `dup_input` to the public event ABI list.
- **Tests** — `test_385_conflicting_duplicate_emits_dup_input_with_stored_result` (verifies the event payload matches the stored result) and `test_385_exact_replay_does_not_emit_dup_input` (replay stays side-effect free).
- **Docs** — `docs/FAILURE_TAXONOMY.md`, `docs/RESULT_PAYLOAD_HASHING.md`, `README.md`, `docs/PROJECT_CONTEXT.md`, `CHANGELOG.md`.

## Event schema

`dup_input` — `topic[0]=dup_input`, `topic[1]=v1`, `topic[2]=severity`; payload mirrors the full `SLAResult` field order:

`(outage_id, status, mttr_minutes, threshold_minutes, amount, payment_type, rating, config_version_hash, recorded_at)`

## Verification

```
cd apexchainx_calculator
cargo fmt --check
cargo clippy -- -D warnings
cargo test --lib        # 572 passed
cargo check --target wasm32-unknown-unknown --lib
```
