### PR TITLE
fix: retention trimming, prune ack, outage lookup, telemetry keys

### DIFF
--- a/apexchainx_calculator/src/api_stability.rs
+++ b/apexchainx_calculator/src/api_stability.rs
@@ -126,7 +126,7 @@ pub fn event_name_symbols() -> [&'static str; 16] {
 pub fn storage_key_symbols() -> [&'static str; 17] {
     [
         "ADMIN", "OPERATOR", "PADMIN", "POP", "CONFIG", "CUSTCFG", "PAUSED", "PAUSEINF", "STATS", "CALCCNT",
-        "VIOLCNT", "CALCLDG", "VIOLLDG", "HIST", "VER", "RETLIM", "LCFGUPD",
+        "VIOLCNT", "CALCTS", "VIOLTS", "HIST", "VER", "RETLIM", "LCFGUPD",
     ]
 }
 

--- a/apexchainx_calculator/src/calculation.rs
+++ b/apexchainx_calculator/src/calculation.rs
@@ -29,7 +29,7 @@ use soroban_sdk::{symbol_short, Address, Env, Symbol, Vec};
 
 use crate::{
     SLAConfig, SLAError, SLAResult, SLAStats, SeverityTelemetry, EVENT_DUP_INPUT, EVENT_SETTLE_INTENT,
-    EVENT_SLA_CALC, EVENT_VERSION, HISTORY_KEY, LAST_CALCULATION_LEDGER_KEY, LAST_VIOLATION_LEDGER_KEY,
+    EVENT_SLA_CALC, EVENT_VERSION, HISTORY_KEY, LAST_CALCULATION_TS_KEY, LAST_VIOLATION_TS_KEY,
     MAX_HISTORY_SIZE, MAX_RECALCS_PER_OUTAGE, PAUSED_KEY, RETENTION_LIMIT_KEY, SEVERITY_CALC_COUNTS_KEY,
     SEVERITY_VIOL_COUNTS_KEY, STATS_KEY,
 };
@@ -318,8 +318,8 @@ pub fn record_severity_telemetry(env: &Env, severity: &Symbol, met: bool) {
     let index = crate::SLACalculatorContract::canonical_severity_index(severity).unwrap_or(0);
     let mut calculations = load_counts(env, &SEVERITY_CALC_COUNTS_KEY);
     let mut violations = load_counts(env, &SEVERITY_VIOL_COUNTS_KEY);
-    let mut last_calculations = load_counts(env, &LAST_CALCULATION_LEDGER_KEY);
-    let mut last_violations = load_counts(env, &LAST_VIOLATION_LEDGER_KEY);
+    let mut last_calculations = load_counts(env, &LAST_CALCULATION_TS_KEY);
+    let mut last_violations = load_counts(env, &LAST_VIOLATION_TS_KEY);
 
     let now = env.ledger().timestamp();
     let week_seconds = 7u64 * 24u64 * 60u64 * 60u64;
@@ -341,14 +341,14 @@ pub fn record_severity_telemetry(env: &Env, severity: &Symbol, met: bool) {
         violations = set_count_lane(violations, index, count_lane(violations, index).saturating_add(1));
     }
 
-    let current_ledger = if now > u64::from(u32::MAX) {
+    let current_ts = if now > u64::from(u32::MAX) {
         u32::MAX
     } else {
         now as u32
     };
-    last_calculations = set_count_lane(last_calculations, index, current_ledger);
+    last_calculations = set_count_lane(last_calculations, index, current_ts);
     if !met {
-        last_violations = set_count_lane(last_violations, index, current_ledger);
+        last_violations = set_count_lane(last_violations, index, current_ts);
     }
 
     env.storage()
@@ -359,10 +359,10 @@ pub fn record_severity_telemetry(env: &Env, severity: &Symbol, met: bool) {
         .set(&SEVERITY_VIOL_COUNTS_KEY, &violations);
     env.storage()
         .instance()
-        .set(&LAST_CALCULATION_LEDGER_KEY, &last_calculations);
+        .set(&LAST_CALCULATION_TS_KEY, &last_calculations);
     env.storage()
         .instance()
-        .set(&LAST_VIOLATION_LEDGER_KEY, &last_violations);
+        .set(&LAST_VIOLATION_TS_KEY, &last_violations);
 }
 
 /// Increments the cumulative SLA statistics, emitting `stats_sat` on overflow.

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -123,11 +123,11 @@ pub(crate) const SEVERITY_CALC_COUNTS_KEY: Symbol = symbol_short!("CALCCNT");
 /// Per-severity weekly violation counters for telemetry. (#101)
 pub(crate) const SEVERITY_VIOL_COUNTS_KEY: Symbol = symbol_short!("VIOLCNT");
 
-/// Per-severity last calculation ledger snapshot for weekly windowing. (#101)
-pub(crate) const LAST_CALCULATION_LEDGER_KEY: Symbol = symbol_short!("CALCLDG");
+/// Per-severity last calculation timestamp for weekly windowing. (#101)
+pub(crate) const LAST_CALCULATION_TS_KEY: Symbol = symbol_short!("CALCTS");
 
-/// Per-severity last violation ledger snapshot for weekly windowing. (#101)
-pub(crate) const LAST_VIOLATION_LEDGER_KEY: Symbol = symbol_short!("VIOLLDG");
+/// Per-severity last violation timestamp for weekly windowing. (#101)
+pub(crate) const LAST_VIOLATION_TS_KEY: Symbol = symbol_short!("VIOLTS");
 
 /// Ordered list of historical SLAResult entries.
 pub(crate) const HISTORY_KEY: Symbol = symbol_short!("HIST");
@@ -1051,8 +1051,8 @@ impl SLACalculatorContract {
         );
         env.storage().instance().set(&SEVERITY_CALC_COUNTS_KEY, &0u128);
         env.storage().instance().set(&SEVERITY_VIOL_COUNTS_KEY, &0u128);
-        env.storage().instance().set(&LAST_CALCULATION_LEDGER_KEY, &0u128);
-        env.storage().instance().set(&LAST_VIOLATION_LEDGER_KEY, &0u128);
+        env.storage().instance().set(&LAST_CALCULATION_TS_KEY, &0u128);
+        env.storage().instance().set(&LAST_VIOLATION_TS_KEY, &0u128);
         env.storage()
             .instance()
             .set(&HISTORY_KEY, &Vec::<SLAResult>::new(&env));
@@ -1127,12 +1127,12 @@ impl SLACalculatorContract {
             inst.set(&SEVERITY_VIOL_COUNTS_KEY, &0u128);
         }
 
-        if !inst.has(&LAST_CALCULATION_LEDGER_KEY) {
-            inst.set(&LAST_CALCULATION_LEDGER_KEY, &0u128);
+        if !inst.has(&LAST_CALCULATION_TS_KEY) {
+            inst.set(&LAST_CALCULATION_TS_KEY, &0u128);
         }
 
-        if !inst.has(&LAST_VIOLATION_LEDGER_KEY) {
-            inst.set(&LAST_VIOLATION_LEDGER_KEY, &0u128);
+        if !inst.has(&LAST_VIOLATION_TS_KEY) {
+            inst.set(&LAST_VIOLATION_TS_KEY, &0u128);
         }
 
         if !inst.has(&HISTORY_KEY) {
@@ -2812,8 +2812,8 @@ impl SLACalculatorContract {
         let index = Self::canonical_severity_index(severity).unwrap_or(0);
         let mut calculations = Self::load_counts(env, &SEVERITY_CALC_COUNTS_KEY);
         let mut violations = Self::load_counts(env, &SEVERITY_VIOL_COUNTS_KEY);
-        let mut last_calculations = Self::load_counts(env, &LAST_CALCULATION_LEDGER_KEY);
-        let mut last_violations = Self::load_counts(env, &LAST_VIOLATION_LEDGER_KEY);
+        let mut last_calculations = Self::load_counts(env, &LAST_CALCULATION_TS_KEY);
+        let mut last_violations = Self::load_counts(env, &LAST_VIOLATION_TS_KEY);
 
         let now = env.ledger().timestamp();
         let week_seconds = 7u64 * 24u64 * 60u64 * 60u64;
@@ -2839,14 +2839,14 @@ impl SLACalculatorContract {
             );
         }
 
-        let current_ledger = if now > u64::from(u32::MAX) {
+        let current_ts = if now > u64::from(u32::MAX) {
             u32::MAX
         } else {
             now as u32
         };
-        last_calculations = Self::set_count_lane(last_calculations, index, current_ledger);
+        last_calculations = Self::set_count_lane(last_calculations, index, current_ts);
         if !met {
-            last_violations = Self::set_count_lane(last_violations, index, current_ledger);
+            last_violations = Self::set_count_lane(last_violations, index, current_ts);
         }
 
         env.storage()
@@ -2857,10 +2857,10 @@ impl SLACalculatorContract {
             .set(&SEVERITY_VIOL_COUNTS_KEY, &violations);
         env.storage()
             .instance()
-            .set(&LAST_CALCULATION_LEDGER_KEY, &last_calculations);
+            .set(&LAST_CALCULATION_TS_KEY, &last_calculations);
         env.storage()
             .instance()
-            .set(&LAST_VIOLATION_LEDGER_KEY, &last_violations);
+            .set(&LAST_VIOLATION_TS_KEY, &last_violations);
     }
 
     fn publish_sla_event(env: &Env, severity: Symbol, result: &SLAResult) {
@@ -2936,7 +2936,7 @@ impl SLACalculatorContract {
             .unwrap_or_else(|| Vec::new(&env));
         let len = history.len();
 
-        if len > keep_latest {
+        let remove_count = if len > keep_latest {
             let remove_count = len - keep_latest;
             let mut new_history = Vec::new(&env);
 
@@ -2946,10 +2946,12 @@ impl SLACalculatorContract {
             }
 
             env.storage().instance().set(&HISTORY_KEY, &new_history);
-            env.events()
-                .publish((EVENT_PRUNED, EVENT_VERSION, caller), (remove_count, keep_latest));
-        }
-
+            remove_count
+        } else {
+            0
+        };
+        env.events()
+            .publish((EVENT_PRUNED, EVENT_VERSION, caller), (remove_count, keep_latest));
         Ok(())
     }
 
@@ -2984,11 +2986,11 @@ impl SLACalculatorContract {
         }
 
         if removed > 0 {
-            let kept = new_history.len();
             env.storage().instance().set(&HISTORY_KEY, &new_history);
-            env.events()
-                .publish((EVENT_PRUNED_AGE, EVENT_VERSION, caller), (removed, kept));
         }
+        let kept = new_history.len();
+        env.events()
+            .publish((EVENT_PRUNED_AGE, EVENT_VERSION, caller), (removed, kept));
 
         Ok(())
     }
@@ -3122,10 +3124,11 @@ impl SLACalculatorContract {
             .get(&HISTORY_KEY)
             .unwrap_or_else(|| Vec::new(&env));
         let mut latest: Option<SLAResult> = None;
-        for i in 0..history.len() {
+        for i in (0..history.len()).rev() {
             let entry = history.get(i).unwrap();
             if entry.outage_id == outage_id {
                 latest = Some(entry);
+                break;
             }
         }
         Ok(latest)
@@ -3170,6 +3173,22 @@ impl SLACalculatorContract {
             return Err(SLAError::RetentionLimitOutOfRange);
         }
         env.storage().instance().set(&RETENTION_LIMIT_KEY, &limit);
+        let history: Vec<SLAResult> = env
+            .storage()
+            .instance()
+            .get(&HISTORY_KEY)
+            .unwrap_or_else(|| Vec::new(&env));
+        let len = history.len();
+        if len > limit {
+            let remove_count = len - limit;
+            let mut new_history = Vec::new(&env);
+            for i in remove_count..len {
+                new_history.push_back(history.get(i).unwrap());
+            }
+            env.storage().instance().set(&HISTORY_KEY, &new_history);
+            env.events()
+                .publish((EVENT_PRUNED, EVENT_VERSION, caller), (remove_count, limit));
+        }
         Ok(())
     }
 

--- a/apexchainx_calculator/src/storage_footprint_tests.rs
+++ b/apexchainx_calculator/src/storage_footprint_tests.rs
@@ -62,7 +62,7 @@ fn storage_key_count_is_stable_after_init() {
     // in lib.rs). Asserting presence pins the post-init footprint so accidental
     // additions or removals are caught.
     let eagerly_written: [&str; 11] = [
-        "ADMIN", "OPERATOR", "CONFIG", "PAUSED", "STATS", "CALCCNT", "VIOLCNT", "CALCLDG", "VIOLLDG", "HIST",
+        "ADMIN", "OPERATOR", "CONFIG", "PAUSED", "STATS", "CALCCNT", "VIOLCNT", "CALCTS", "VIOLTS", "HIST",
         "VER",
     ];
 

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -426,8 +426,8 @@ fn test_storage_key_namespace_symbols_are_distinct() {
     //   STATS_KEY                  = "STATS"
     //   SEVERITY_CALC_COUNTS_KEY   = "CALCCNT"
     //   SEVERITY_VIOL_COUNTS_KEY   = "VIOLCNT"
-    //   LAST_CALCULATION_LEDGER_KEY= "CALCLDG"
-    //   LAST_VIOLATION_LEDGER_KEY  = "VIOLLDG"
+    //   LAST_CALCULATION_TS_KEY     = "CALCTS"
+    //   LAST_VIOLATION_TS_KEY       = "VIOLTS"
     //   HISTORY_KEY                = "HIST"
     //   STORAGE_VERSION_KEY        = "VER"
     //   RETENTION_LIMIT_KEY        = "RETLIM"
@@ -445,8 +445,8 @@ fn test_storage_key_namespace_symbols_are_distinct() {
         STATS_KEY,
         SEVERITY_CALC_COUNTS_KEY,
         SEVERITY_VIOL_COUNTS_KEY,
-        LAST_CALCULATION_LEDGER_KEY,
-        LAST_VIOLATION_LEDGER_KEY,
+        LAST_CALCULATION_TS_KEY,
+        LAST_VIOLATION_TS_KEY,
         HISTORY_KEY,
         STORAGE_VERSION_KEY,
         RETENTION_LIMIT_KEY,
@@ -4028,12 +4028,9 @@ fn test_retention_limit_drops_oldest_when_exceeded() {
 }
 
 #[test]
-fn test_retention_limit_update_takes_effect_on_next_calculate() {
-    // The retention limit only prevents growth beyond the cap; it does not
-    // retroactively shrink existing history. When the limit is lowered below
-    // the current history size, each subsequent calculate_sla call pushes one
-    // entry and drops one (net zero change) until the history naturally drains
-    // to the new limit via prune_history or prune_history_by_age.
+fn test_retention_limit_update_trims_existing_history() {
+    // Lowering the retention limit immediately trims existing history to the
+    // new limit and emits the prune event; raising it never trims.
     let env = Env::default();
     env.mock_all_auths();
     env.budget().reset_unlimited();
@@ -4051,32 +4048,25 @@ fn test_retention_limit_update_takes_effect_on_next_calculate() {
     }
     assert_eq!(client.get_history().len(), 10);
 
-    // Lower the limit; existing history is not pruned automatically
+    // Raise the limit first; nothing is trimmed.
+    client.set_retention_limit(&admin, &20);
+    assert_eq!(client.get_history().len(), 10, "Raising the limit must not prune");
+
+    // Lower the limit; existing history is trimmed immediately to 5.
     client.set_retention_limit(&admin, &5);
     assert_eq!(
         client.get_history().len(),
-        10,
-        "Lowering limit must not retroactively prune"
-    );
-
-    // Each calculate_sla call pushes 1 and drops 1 (net zero) while history > limit.
-    // History stays at 10 until an explicit prune brings it to the new limit.
-    client.calculate_sla(&op, &symbol_short!("AFT"), &symbol_short!("low"), &10);
-    assert_eq!(
-        client.get_history().len(),
-        10,
-        "History stays at 10 (push 1, drop 1)"
-    );
-
-    // Explicit prune brings history down to the new limit
-    client.prune_history(&admin, &5);
-    assert_eq!(
-        client.get_history().len(),
         5,
-        "Explicit prune must enforce the new limit"
+        "Lowering the limit must trim existing history immediately"
     );
 
-    // Now the cap is active: further calculations stay at 5
+    // The trim emits the prune event (removed=5, kept=5).
+    let events = env.events().all();
+    let (_, _, data) = events.last().unwrap();
+    let payload: (u32, u32) = data.try_into_val(&env).unwrap();
+    assert_eq!(payload, (5u32, 5u32));
+
+    // The cap is active: further calculations stay at 5.
     client.calculate_sla(&op, &symbol_short!("CAP"), &symbol_short!("low"), &10);
     assert_eq!(
         client.get_history().len(),


### PR DESCRIPTION
Resolves #410
Resolves #411
Resolves #412
Resolves #413

## Summary

- **#410 — Cheap outage lookup**: `get_latest_by_outage` now scans from the newest end and returns the first match, avoiding a full O(n) pass for the common "is this outage settled?" read.
- **#411 — Retention trims existing history**: `set_retention_limit` now trims already-stored history down to the new limit (and the pinned test that documented the old no-trim behavior was updated accordingly).
- **#412 — Observable no-op prunes**: `prune_history` and `prune_history_by_age` now emit their ack events even when no-op (`removed = 0`).
- **#413 — Telemetry keys reflect timestamps**: the telemetry storage keys (`CALCLDG`→`CALCTS`, `VIOLLDG`→`VIOLTS`) were renamed to match the timestamp values they store.

All `cargo build`, `cargo test --lib`, `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` pass.
