### PR TITLE
fix: close #491, #492, #493, #494 — orphan lint, api-descriptor guardrail, pause_info convention, fingerprint error propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
       - name: no_std compatibility lint (early gate)
         run: ./scripts/check-no-std.sh
 
+      # Issue #491: Orphan module lint — fails when a `.rs` file in the crate
+      # is never declared as a module (e.g. the committed scratch_test.rs that
+      # shipped for weeks without CI noticing). An undeclared file is invisible
+      # to cargo check/clippy/test, so its tests rot silently; this gate closes
+      # that class.
+      - name: Orphan module lint (early gate)
+        run: ./scripts/check-orphan-modules.sh
+
       # Issue #12: WASM no-std compliance check.
       # Compiles only the library crate for wasm32-unknown-unknown so that any
       # accidental `std` import surfaces here (before deployment) as a compile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,12 @@
   - Performs configuration parameter validation (SC-W5-046)
 - `get_stats` now returns a `SLAStats` struct; callers should use field access rather than tuple destructuring
 - History entries returned by `get_history` include `schema_version` for result envelope versioning
+- `get_contract_state_fingerprint` no longer reports `config_version_hash = 0` when the config is unreadable. Previously an unreadable `CONFIG_KEY` (storage corruption, bad migration) was masked with `unwrap_or(0)`, making a corrupt config indistinguishable from a legitimate hash — which is never 0 — and defeating the endpoint's incident-response purpose. A config-hash failure now propagates as `NotInitialized`/`ConfigNotFound`, and the documented error contract was updated to match; tests cover the missing-key and partially-missing-config paths (#494)
+
+### Added
+- `scripts/check-orphan-modules.sh` — orphan-module lint that fails when a `.rs` file under the crate is never declared as a module (an undeclared file is invisible to cargo check/clippy/test, so its tests rot silently). Wired into CI as an early gate and available as `just lint-orphans`. The leftover `apexchainx_calculator/scratch_test.rs` was removed as part of this (#491)
+- `get_public_api` descriptor completeness guardrail — `test_492_descriptor_covers_every_public_method` and `test_492_descriptor_lists_only_declared_methods` compare the hand-enumerated descriptor against the canonical `CANONICAL_PUBLIC_METHODS` list in both directions, so a public method missing from the descriptor or a descriptor entry that no longer exists on the impl fails CI (#492)
+- `AuditState.pause_info` invariant enforcement — a test pins the `Vec`-stands-in-for-`Option` convention (empty when unpaused, exactly one element when paused, always matching `get_pause_info`), and `CODING_STYLE.md` Part 3 documents the single convention governing absent state across `#[contracttype]` surfaces; Part 4 documents the module-declaration and scratch-code policy (#493)
 
 ---
 

--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -282,4 +282,107 @@ If a property is expressed in a test and in a comment, the comment is likely to 
 
 This policy is enforced through the PR review checklist above. Reviewers must verify compliance with each category before approving. Automated enforcement via `cargo clippy` lints (`missing_docs`, `clippy::missing_errors_doc`) is enabled for public items; violations block CI.
 
+---
+
+## Part 3 — Optional-State Convention for `#[contracttype]` Surfaces (Issue #493)
+
+This section defines the single convention for representing **absent** state
+across `#[contracttype]` struct fields, so consumers never have to learn two
+shapes for the same semantic.
+
+### The SDK limitation
+
+`#[contracttype]` structs cannot contain `Option<T>` fields: the SDK's ScVal
+conversion for a derived `#[contracttype]` struct has no `From<&Option<T>>`
+impl, so a struct with an `Option` field does not compile. This is a platform
+limitation, not a design choice — every surface hits it independently and
+must apply the same rule.
+
+### The convention
+
+1. **`#[contracttype]` struct fields model absent state with `Vec<T>`.**
+   Empty = absent; single-element = present. Every such field must carry a
+   comment stating its **max-length invariant** (e.g. `len() <= 1`) so the
+   "one element max" rule is reviewable, plus the invariant must be pinned by
+   a test.
+2. **Getters may return `Result<Option<T>, _>`.** Function return values are
+   not subject to the `#[contracttype]` field limitation, so the read surface
+   (`get_pause_info`, `get_pending_admin`, `get_pending_operator`) uses
+   `Option` directly. The `Vec` field in an aggregate struct is the *wire*
+   representation; the `Option` getter is the *semantic* one, and they must
+   agree (empty ⇔ `None`, one element ⇔ `Some(_)`).
+3. **Never invent a second representation.** If a field can be absent, do not
+   use a sentinel value, a zero-address, or a `bool` flag alongside a `Vec` —
+   use the `Vec` convention and document the invariant.
+
+### Example
+
+```rust
+/// Pause metadata when paused, empty otherwise. `Vec` stands in for `Option`
+/// because `#[contracttype]` cannot convert `Option<PauseInfo>` (#493).
+/// INVARIANT: `pause_info.len() <= 1` — empty = unpaused, one element = paused.
+pub pause_info: Vec<PauseInfo>,
+```
+
+The invariant above is enforced by `audit_state::tests::
+test_audit_state_pause_info_invariant_across_pause_cycle`, which asserts
+empty ⇔ unpaused and exactly-one ⇔ paused, and that both match
+`get_pause_info()`.
+
+### Review checklist
+
+- [ ] Every new `#[contracttype]` struct field that can be absent uses `Vec<T>`
+      with a documented max-length invariant (Part 3 convention), never a
+      sentinel or a parallel `bool`.
+- [ ] The aggregate field and its `Option`-typed getter agree, pinned by a test.
+- [ ] Changing a `#[contracttype]` field's shape (e.g. `Vec<PauseInfo>` → a
+      wrapper) is an ABI change and must go through the stability process
+      (`api_stability.rs` field counts, schema version bump) — see
+      `docs/CONTRACT_SHAPE_CHANGE_CHECKLIST.md`.
+
+---
+
+## Part 4 — Module Declaration and Scratch Code Policy (Issue #491)
+
+This section defines where `.rs` files may live and where throwaway code
+belongs, so the crate never again ships code that CI cannot see.
+
+### The rule
+
+**Every `.rs` file under the crate must be declared as a module.** A file that
+exists on disk but is never declared is invisible to `cargo check`/`clippy`/
+`test` — it silently stops compiling and running, and its tests rot without
+any red flag. This is enforced by `scripts/check-orphan-modules.sh` (CI early
+gate and `just lint-orphans`), which fails on any undeclared `.rs` file under
+`apexchainx_calculator/`.
+
+Declaring a module is one line in `src/lib.rs`:
+
+```rust
+pub mod my_module;        // compiled into the contract
+#[cfg(test)]
+mod my_module_tests;      // test-only, compiled by `cargo test`
+```
+
+### Where throwaway code belongs
+
+Interactive experiments, scratch helpers, and one-off probes must **not** be
+committed to the crate. They belong in:
+
+- `/tmp` or a scratch directory outside the repository,
+- the fuzz corpus (`apexchainx_calculator/fuzz/`), when they are real
+  invariants worth fuzzing, or
+- a local branch that is never merged.
+
+If an experiment genuinely must live in the tree for a review cycle, it must
+be declared as a module (so CI compiles it and the orphan lint passes) and
+carry a `// TODO(#issue): remove` marker tracking its deletion.
+
+### Review checklist
+
+- [ ] No `.rs` file is added to the crate without a matching `mod` declaration
+      in `src/lib.rs` (`just lint-orphans` passes).
+- [ ] No scratch/experimental code is committed; experiments live in `/tmp`,
+      the fuzz corpus, or a never-merged branch.
+
 For questions or proposed policy amendments, open an issue referencing this document.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,11 @@ git checkout -b refactor/storage-layer
 - Update documentation as needed
 - Keep commits **focused and atomic** — one logical change per commit
 - Update `CHANGELOG.md` for any interface-affecting changes
+- **Never commit scratch/experimental code to the crate.** Throwaway probes
+  belong in `/tmp`, the fuzz corpus, or a branch that is never merged; every
+  `.rs` file that does land must be declared as a module in `src/lib.rs` or
+  the orphan-module lint (`just lint-orphans`) fails. See `CODING_STYLE.md`
+  Part 4 (#491).
 
 ### Step 3: Run Tests
 
@@ -293,6 +298,11 @@ Then open a pull request on GitHub with:
 - **Gas efficiency:** Minimize storage writes, avoid unnecessary loops
 - **Safety:** Use integer math only, validate all inputs, fail early
 - **Documentation:** All public functions must have doc comments following the canonical comment policy
+- **Optional state in `#[contracttype]` fields:** `Option<T>` cannot be a
+  `#[contracttype]` field, so absent state uses `Vec<T>` with a documented
+  max-length invariant (empty = absent, single-element = present); getters may
+  return `Result<Option<T>, _>`. Every new `#[contracttype]` struct follows
+  this convention — see `CODING_STYLE.md` Part 3 (#493).
 
 #### Style Rules
 

--- a/apexchainx_calculator/scratch_test.rs
+++ b/apexchainx_calculator/scratch_test.rs
@@ -1,5 +1,0 @@
-use soroban_sdk::{Env, Symbol};
-
-pub fn test_sym(env: &Env) -> Symbol {
-    Symbol::new(env, "migrate_done")
-}

--- a/apexchainx_calculator/src/audit_state.rs
+++ b/apexchainx_calculator/src/audit_state.rs
@@ -22,8 +22,12 @@ pub struct AuditState {
     pub pending_operator: Option<Address>,
     /// Whether the contract is currently paused.
     pub paused: bool,
-    /// Empty when unpaused, single-element when paused. A `Vec` stands in for
-    /// `Option` because `#[contracttype]` cannot convert `Option<PauseInfo>`.
+    /// Pause metadata when paused, empty otherwise. Follows the crate-wide
+    /// optional-state convention for `#[contracttype]` fields (CODING_STYLE.md
+    /// Part 3, #493): `Option<T>` cannot be a `#[contracttype]` field, so a
+    /// `Vec<T>` stands in with a max-length invariant — empty = absent,
+    /// single-element = present. INVARIANT: `pause_info.len() <= 1`; the
+    /// getter surfaces (`get_pause_info`) use `Option<PauseInfo>` directly.
     pub pause_info: Vec<PauseInfo>,
     /// Ordered snapshot of all severity configurations.
     pub config_snapshot: SLAConfigSnapshot,
@@ -85,5 +89,35 @@ mod tests {
         let state = client.get_full_audit_state();
         assert_eq!(state.history_len, 2);
         assert_eq!(state.stats.total_calculations, 2);
+    }
+
+    // #493 – the pause_info Vec-stands-in-for-Option invariant: empty when
+    // unpaused, exactly one element when paused, and always consistent with
+    // the Option-typed getter surface.
+    #[test]
+    fn test_audit_state_pause_info_invariant_across_pause_cycle() {
+        let (env, client, admin, _operator) = setup();
+
+        // Unpaused: empty, matching get_pause_info() == None.
+        let state = client.get_full_audit_state();
+        assert!(!state.paused);
+        assert!(state.pause_info.is_empty());
+        assert!(state.pause_info.len() <= 1);
+        assert_eq!(state.pause_info.first(), client.get_pause_info());
+
+        // Paused: exactly one element, matching get_pause_info() == Some(_).
+        client.pause(&admin, &soroban_sdk::String::from_str(&env, "maintenance"));
+        let state = client.get_full_audit_state();
+        assert!(state.paused);
+        assert_eq!(state.pause_info.len(), 1);
+        assert!(state.pause_info.len() <= 1);
+        assert_eq!(state.pause_info.first(), client.get_pause_info());
+
+        // Unpaused again: back to empty.
+        client.unpause(&admin);
+        let state = client.get_full_audit_state();
+        assert!(!state.paused);
+        assert!(state.pause_info.is_empty());
+        assert_eq!(state.pause_info.first(), client.get_pause_info());
     }
 }

--- a/apexchainx_calculator/src/lib.rs
+++ b/apexchainx_calculator/src/lib.rs
@@ -3469,8 +3469,19 @@ impl SLACalculatorContract {
     /// # Errors
     ///
     /// Returns `NotInitialized` if the contract has never been initialized (no
-    /// `STORAGE_VERSION_KEY` present). All other contract states return a valid
-    /// fingerprint, including pre-migration and paused states.
+    /// `STORAGE_VERSION_KEY` present).
+    ///
+    /// Returns `NotInitialized` or `ConfigNotFound` when the configuration is
+    /// unreadable (e.g. `CONFIG_KEY` is missing or a canonical severity is absent
+    /// from the stored map). This is deliberate (#494): a corrupt config must not
+    /// be reported as a valid fingerprint with a bogus `config_version_hash` of
+    /// `0` — an operator comparing pre/post-upgrade fingerprints would otherwise
+    /// be unable to tell a corrupt config from a merely different one. The
+    /// endpoint's audit purpose (release review, upgrade planning, incident
+    /// response) requires the unreadable-config case to surface as an error.
+    ///
+    /// All *readable* contract states return a valid fingerprint, including
+    /// pre-migration and paused states.
     ///
     /// # Safety
     ///
@@ -3490,9 +3501,12 @@ impl SLACalculatorContract {
         let needs_migration = stored_version != STORAGE_VERSION;
 
         // Config version hash computation is safe even in pre-migration state
-        // because load_config works across all initialized states.
-        // If config is unreadable, fall back to sentinel 0.
-        let config_version_hash: u64 = Self::compute_config_version_hash(&env).unwrap_or(0);
+        // because load_config works across all initialized states. An unreadable
+        // config (missing CONFIG_KEY, or a canonical severity absent from the
+        // map) is propagated as an error rather than masked with a sentinel 0:
+        // a legitimate hash is never 0, so 0 would be indistinguishable from a
+        // corrupt config (see #494).
+        let config_version_hash: u64 = Self::compute_config_version_hash(&env)?;
 
         // Pause and freeze state default to false if keys are absent.
         let is_paused: bool = env.storage().instance().get(&PAUSED_KEY).unwrap_or(false);

--- a/apexchainx_calculator/src/tests.rs
+++ b/apexchainx_calculator/src/tests.rs
@@ -8687,6 +8687,90 @@ fn test_261_fingerprint_fails_on_uninitialized_contract() {
 }
 
 // ============================================================
+// Issue #494 – a config-hash failure inside the fingerprint must be
+// distinguishable from a valid hash.
+// ============================================================
+//
+// get_contract_state_fingerprint previously masked an unreadable config with
+// `unwrap_or(0)`, so a corrupt CONFIG_KEY was reported as a valid fingerprint
+// with config_version_hash = 0 — indistinguishable from a legitimate hash
+// (which can never be 0: the polynomial's seed is 1). The endpoint now
+// propagates the config read error, so an operator comparing pre/post-upgrade
+// fingerprints sees a loud failure instead of a bogus zero.
+
+#[test]
+#[should_panic]
+fn test_494_fingerprint_fails_when_config_key_missing() {
+    // Simulate storage corruption: the storage version exists (so the contract
+    // is "initialized") but CONFIG_KEY has been removed. The fingerprint must
+    // not silently report config_version_hash = 0 — it must fail.
+    let (env, client, _actors) = setup();
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().remove(&CONFIG_KEY);
+    });
+
+    client.get_contract_state_fingerprint();
+}
+
+#[test]
+#[should_panic]
+fn test_494_fingerprint_fails_when_config_partially_missing() {
+    // A partially-missing config: CONFIG_KEY exists but the stored map lacks one
+    // of the four canonical severities. compute_config_version_hash must surface
+    // ConfigNotFound rather than fabricate a hash over a partial config.
+    let (env, client, _actors) = setup();
+
+    let mut partial: soroban_sdk::Map<Symbol, SLAConfig> = soroban_sdk::Map::new(&env);
+    partial.set(
+        symbol_short!("critical"),
+        SLAConfig {
+            threshold_minutes: 30,
+            penalty_per_minute: 100,
+            reward_base: 1000,
+        },
+    );
+    partial.set(
+        symbol_short!("high"),
+        SLAConfig {
+            threshold_minutes: 120,
+            penalty_per_minute: 50,
+            reward_base: 800,
+        },
+    );
+    partial.set(
+        symbol_short!("medium"),
+        SLAConfig {
+            threshold_minutes: 240,
+            penalty_per_minute: 25,
+            reward_base: 500,
+        },
+    );
+    // Note: no "low" entry — the map is partial.
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&CONFIG_KEY, &partial);
+    });
+
+    client.get_contract_state_fingerprint();
+}
+
+#[test]
+fn test_494_fingerprint_hash_never_zero_on_readable_config() {
+    // The positive contract: with a readable config, the hash is never 0, so 0
+    // remains an unambiguous signal that something is wrong. This pins the
+    // "0 is only reachable via the old fallback" property from the issue.
+    let (_env, client, actors) = setup();
+    let fingerprint = client.get_contract_state_fingerprint();
+    assert_ne!(fingerprint.config_version_hash, 0);
+
+    // Also non-zero after a config update (the hash changes, but stays valid).
+    client.set_config(&actors.admin, &symbol_short!("critical"), &20, &200, &1000);
+    let fingerprint = client.get_contract_state_fingerprint();
+    assert_ne!(fingerprint.config_version_hash, 0);
+}
+
+// ============================================================
 // #244 – Public API descriptor tests
 // ============================================================
 
@@ -8842,6 +8926,174 @@ fn test_get_public_api_requires_initialization() {
 
     // No initialize() called — get_public_api must panic
     client.get_public_api();
+}
+
+// ============================================================
+// Issue #492 – get_public_api descriptor completeness guardrail
+// ============================================================
+//
+// get_public_api() hand-enumerates the API surface, and for a long time the
+// descriptor drifted from the #[contractimpl] block (get_contract_info,
+// get_storage_footprint_estimate and get_rent_estimate were missing, #418)
+// with no test noticing. These tests are the enforcement mechanism: they
+// compare the descriptor against CANONICAL_PUBLIC_METHODS in BOTH directions.
+//
+// CANONICAL_PUBLIC_METHODS is the impl-truth list — it must contain exactly
+// the public methods the #[contractimpl] block exposes, with their documented
+// (mutates, auth, event) metadata. When you add, remove, or rename a public
+// contract method:
+//   1. update the #[contractimpl] block in lib.rs,
+//   2. update get_public_api() in lib.rs, and
+//   3. update CANONICAL_PUBLIC_METHODS here.
+//
+// Forgetting any one of the three fails one of the two tests below, so the
+// drift class is closed in both directions:
+//   - a public method absent from the descriptor fails
+//     test_492_descriptor_covers_every_public_method,
+//   - a descriptor entry that no longer exists on the impl fails
+//     test_492_descriptor_lists_only_declared_methods.
+//
+// The auth/mutates/event columns encode intent and cannot be derived
+// mechanically from the Rust signature, so they are pinned here as the
+// documented metadata (see #492 out-of-scope notes on mechanical derivation).
+const CANONICAL_PUBLIC_METHODS: &[(&str, bool, &str, &str)] = &[
+    // Lifecycle: two-step role handoff. accept_* are called by the proposed
+    // address (not the current role holder), so auth is "none".
+    ("accept_admin", true, "none", "adm_acc"),
+    ("accept_operator", true, "none", "op_acc"),
+    // Calculation:
+    ("calculate_sla", true, "operator", "sla_calc"),
+    ("calculate_sla_view", false, "none", ""),
+    ("cancel_admin_proposal", true, "admin", "adm_can"),
+    ("cancel_operator_proposal", true, "admin", "op_can"),
+    // Config:
+    ("freeze_config", true, "admin", "cfg_frz"),
+    ("get_admin", false, "none", ""),
+    ("get_config", false, "none", ""),
+    ("get_config_bundle", false, "none", ""),
+    ("get_config_count", false, "none", ""),
+    ("get_config_snapshot", false, "none", ""),
+    ("get_config_version_hash", false, "none", ""),
+    ("get_contract_info", false, "none", ""),
+    ("get_contract_metadata", false, "none", ""),
+    ("get_contract_state_fingerprint", false, "none", ""),
+    ("get_custom_config_snapshot", false, "none", ""),
+    ("get_custom_severity", false, "none", ""),
+    ("get_economic_exposure", false, "none", ""),
+    ("get_failure_schema", false, "none", ""),
+    ("get_full_audit_state", false, "none", ""),
+    ("get_history", false, "none", ""),
+    ("get_history_by_outage", false, "none", ""),
+    ("get_history_page", false, "none", ""),
+    ("get_history_page_with_meta", false, "none", ""),
+    ("get_latest_by_outage", false, "none", ""),
+    ("get_last_config_update", false, "none", ""),
+    ("get_migration_state", false, "none", ""),
+    ("get_operator", false, "none", ""),
+    ("get_pause_info", false, "none", ""),
+    ("get_pending_admin", false, "none", ""),
+    ("get_pending_operator", false, "none", ""),
+    ("get_public_api", false, "none", ""),
+    ("get_rent_estimate", false, "none", ""),
+    ("get_result_schema", false, "none", ""),
+    ("get_retention_limit", false, "none", ""),
+    ("get_severity_telemetry", false, "none", ""),
+    ("get_stats", false, "none", ""),
+    ("get_storage_footprint_estimate", false, "none", ""),
+    ("get_storage_version", false, "none", ""),
+    ("get_version_info", false, "none", ""),
+    // Health:
+    ("healthcheck", false, "none", ""),
+    // Init:
+    ("initialize", true, "admin", ""),
+    ("is_config_frozen", false, "none", ""),
+    ("is_paused", false, "none", ""),
+    ("list_configs", false, "none", ""),
+    // Migration:
+    ("migrate", true, "admin", "migrate_done"),
+    // Pause:
+    ("pause", true, "admin", "paused"),
+    ("propose_admin", true, "admin", "adm_prop"),
+    ("propose_operator", true, "admin", "op_prop"),
+    ("prune_history", true, "admin", "pruned"),
+    ("prune_history_by_age", true, "admin", "pruned_a"),
+    ("remove_custom_severity", true, "admin", "cfg_upd"),
+    ("renounce_admin", true, "admin", "adm_ren"),
+    ("replay_calculate_sla", true, "operator", "sla_calc"),
+    // Setters:
+    ("set_config", true, "admin", "cfg_upd"),
+    ("set_custom_severity", true, "admin", "cfg_upd"),
+    ("set_operator", true, "admin", "op_set"),
+    ("set_retention_limit", true, "admin", ""),
+    ("unfreeze_config", true, "admin", "cfg_unfrz"),
+    ("unpause", true, "admin", "unpause"),
+];
+
+#[test]
+fn test_492_descriptor_covers_every_public_method() {
+    // Direction 1: every impl-truth method must appear in the descriptor with
+    // identical metadata. Fails when a public #[contractimpl] method is absent
+    // from get_public_api (or its metadata drifted).
+    let (_env, client, _actors) = setup();
+    let api = client.get_public_api();
+
+    for (name, mutates, auth, event) in CANONICAL_PUBLIC_METHODS {
+        let mut found = false;
+        for i in 0..api.methods.len() {
+            let method = api.methods.get(i).unwrap();
+            if method.name == Symbol::new(&_env, name) {
+                found = true;
+                assert_eq!(
+                    method.mutates, *mutates,
+                    "get_public_api mutates flag for {} drifted from the impl",
+                    name
+                );
+                assert_eq!(
+                    method.auth,
+                    Symbol::new(&_env, auth),
+                    "get_public_api auth for {} drifted from the impl",
+                    name
+                );
+                assert_eq!(
+                    method.event,
+                    Symbol::new(&_env, event),
+                    "get_public_api event for {} drifted from the impl",
+                    name
+                );
+            }
+        }
+        assert!(
+            found,
+            "public method '{}' is missing from get_public_api — add it to the \
+             descriptor in lib.rs (and keep CANONICAL_PUBLIC_METHODS in sync)",
+            name
+        );
+    }
+}
+
+#[test]
+fn test_492_descriptor_lists_only_declared_methods() {
+    // Direction 2: every descriptor entry must exist on the impl. Fails when
+    // the descriptor lists a method that was removed from the #[contractimpl]
+    // block (or when CANONICAL_PUBLIC_METHODS was pruned without updating the
+    // descriptor).
+    let (_env, client, _actors) = setup();
+    let api = client.get_public_api();
+
+    let declared: alloc::collections::BTreeSet<&str> =
+        CANONICAL_PUBLIC_METHODS.iter().map(|(name, ..)| *name).collect();
+
+    for i in 0..api.methods.len() {
+        let method = api.methods.get(i).unwrap();
+        let name = method.name.to_string();
+        assert!(
+            declared.contains(name.as_str()),
+            "get_public_api lists '{}' but it is not a declared public method — \
+             remove it from the descriptor in lib.rs (or add it to the \
+             #[contractimpl] block and CANONICAL_PUBLIC_METHODS)",
+            name
+        );
+    }
 }
 
 #[test]

--- a/justfile
+++ b/justfile
@@ -218,6 +218,12 @@ wasm-release:
 no-std:
     cd {{crate}} && cargo check --target {{wasm_target}} --lib
 
+# Fail when a .rs file in the crate is never declared as a module (#491).
+# An undeclared file is invisible to cargo check/clippy/test and rots silently;
+# see scripts/check-orphan-modules.sh.                    [CI: client-checks]
+lint-orphans:
+    ./scripts/check-orphan-modules.sh
+
 # sha256 of the release WASM.            [CI: Generate hash]
 hash: wasm-release
     #!/usr/bin/env bash
@@ -340,5 +346,5 @@ clean:
     cd {{crate}} && cargo clean
 
 # Everything CI gates on, in CI's order. Run before opening a PR.
-ci: fmt-check lint check no-std test fuzz fuzz-spec parity-check ts-check wasm machete udeps verify-snapshots
+ci: fmt-check lint check no-std lint-orphans test fuzz fuzz-spec parity-check ts-check wasm machete udeps verify-snapshots
     @echo "✓ local CI equivalent passed"

--- a/scripts/check-orphan-modules.sh
+++ b/scripts/check-orphan-modules.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Orphan Module Lint (issue #491)
+# =============================================================================
+#
+# Fails when a `.rs` file under the apexchainx_calculator crate is never
+# declared as a module. A file that exists on disk but is never declared is
+# invisible to `cargo check` / `clippy` / `test`: it silently stops compiling
+# (and running), so its tests, docs and safety guarantees rot without CI ever
+# noticing — exactly what happened to `scratch_test.rs` (a leftover interactive
+# experiment committed at the crate root) and to the src/ orphans tracked by
+# issue #422.
+#
+# What this lint checks:
+#   1. Crate-root `.rs` files (apexchainx_calculator/*.rs). A file sitting next
+#      to Cargo.toml is never part of the module graph unless referenced via
+#      `#[path]`/`include!`, so any such file is an orphan. Throwaway code
+#      belongs in /tmp, the fuzz corpus, or a never-merged branch — not here.
+#   2. `src/*.rs` files whose stem is not declared as a module in `src/lib.rs`
+#      (e.g. `mod foo;` / `pub mod foo;` / `#[cfg(test)] mod foo;`).
+#
+# Subdirectories under src/ (defaults/, fixtures/, metrics/) are excluded: they
+# have their own `mod.rs` structure and are declared as a unit from lib.rs.
+# The fuzz/ workspace and target/ are excluded for the same reason.
+#
+# Usage:
+#   ./scripts/check-orphan-modules.sh     # scan from repo root
+#
+# Exit codes:
+#   0 – no undeclared `.rs` files (beyond the tracked allowlist)
+#   1 – one or more undeclared `.rs` files found
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CRATE_DIR="$REPO_ROOT/apexchainx_calculator"
+LIB_RS="$CRATE_DIR/src/lib.rs"
+
+# ---------------------------------------------------------------------------
+# Known orphans, tracked by companion issue #422 and restored in PR #545.
+#
+# These files are present under src/ but are not (yet) declared as modules,
+# because they do not compile against the current contract API — #545 carries
+# the fixes (pause() gained a reason argument, calculate_sla requires distinct
+# outage ids, the generated client is lifetime-parameterised, symbol lengths
+# were shortened, …). Declaring them here without those fixes would break the
+# build, and duplicating #545's fixes would conflict with it.
+#
+# When #545 lands and declares these modules, this list becomes stale: the
+# files will no longer be orphans, and this script will print a warning (and
+# still pass) until the entries are removed.
+# ---------------------------------------------------------------------------
+ALLOWLIST=(
+    auth_matrix_tests.rs
+    deployment_policy.rs
+    event_ordering_tests.rs
+    event_state_tests.rs
+    outage_id_tests.rs
+    payload_optimizer.rs
+    payload_versioning_tests.rs
+    policy.rs
+    pruning_perf.rs
+    threshold_config.rs
+    topic_stability_tests.rs
+)
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+ORPHANS=()
+STALE_ALLOWLIST=()
+
+# --- Check 1: crate-root .rs files (the scratch_test.rs class) --------------
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    ORPHANS+=("$file")
+done < <(find "$CRATE_DIR" -maxdepth 1 -name '*.rs' 2>/dev/null | sort)
+
+# --- Check 2: src/*.rs files not declared in src/lib.rs ----------------------
+# Extract declared module names: `mod foo;`, `pub mod foo;`, `pub(crate) mod foo;`
+# (and the same after a `#[cfg(...)]` attribute line). Inline `mod foo { … }`
+# blocks are not file modules and must NOT be counted.
+DECLARED="$(grep -E '^[[:space:]]*(pub(\([^)]*\))?[[:space:]]+)?mod[[:space:]]+[a-zA-Z0-9_]+[[:space:]]*;' "$LIB_RS" \
+    | sed -E 's/^[[:space:]]*(pub(\([^)]*\))?[[:space:]]+)?mod[[:space:]]+([a-zA-Z0-9_]+)[[:space:]]*;.*/\3/')"
+
+while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    stem="$(basename "$file" .rs)"
+    if ! grep -qx "$stem" <<<"$DECLARED"; then
+        ORPHANS+=("$(basename "$file")")
+    fi
+done < <(find "$CRATE_DIR/src" -maxdepth 1 -name '*.rs' ! -name 'lib.rs' ! -name 'main.rs' 2>/dev/null | sort)
+
+# --- Separate tracked orphans from new ones ----------------------------------
+UNTRACKED=()
+for name in "${ORPHANS[@]}"; do
+    if printf '%s\n' "${ALLOWLIST[@]}" | grep -qx "$name"; then
+        # Still an orphan → it is tracked; nothing to do. If it is now declared
+        # it would not appear in ORPHANS at all, so nothing else here.
+        :
+    else
+        UNTRACKED+=("$name")
+    fi
+done
+
+# Warn about allowlist entries that are no longer orphans (now declared).
+for name in "${ALLOWLIST[@]}"; do
+    if ! printf '%s\n' "${ORPHANS[@]}" | grep -qx "$name"; then
+        STALE_ALLOWLIST+=("$name")
+    fi
+done
+
+# --- Report ----------------------------------------------------------------
+if [ "${#UNTRACKED[@]}" -gt 0 ]; then
+    echo -e "${RED}==========================================================================${NC}"
+    echo -e "${RED}  ORPHAN MODULE LINT FAILED — undeclared .rs files found${NC}"
+    echo -e "${RED}==========================================================================${NC}"
+    echo ""
+    echo "These .rs files exist in the crate but are never declared as a module,"
+    echo "so cargo never compiles them and their tests never run:"
+    echo ""
+    for name in "${UNTRACKED[@]}"; do
+        echo "  - $name"
+    done
+    echo ""
+    echo -e "${YELLOW}Fix:${NC}"
+    echo "  - Throwaway/scratch code does not belong in the crate at all: keep it"
+    echo "    in /tmp, the fuzz corpus, or a branch that is never merged."
+    echo "  - Real modules/tests: declare them in src/lib.rs, e.g."
+    echo "        pub mod my_module;      # or  #[cfg(test)] mod my_module_tests;"
+    echo "    and make sure the file compiles (an undeclared file has been"
+    echo "    invisible to CI, so it may need fixes before it builds)."
+    echo ""
+    echo "  See issue #491 (scratch_test.rs cleanup) and issue #422 (the"
+    echo "  tracked orphan modules)."
+    echo ""
+    exit 1
+fi
+
+if [ "${#STALE_ALLOWLIST[@]}" -gt 0 ]; then
+    echo -e "${YELLOW}Warning: allowlist entries in scripts/check-orphan-modules.sh are no longer orphans${NC}"
+    echo "  (they are now declared as modules) — remove them from ALLOWLIST:"
+    for name in "${STALE_ALLOWLIST[@]}"; do
+        echo "  - $name"
+    done
+    echo ""
+fi
+
+echo -e "${GREEN}Orphan module lint passed — every .rs file in the crate is declared as a module.${NC}"
+exit 0


### PR DESCRIPTION
Fixes #491
Fixes #492
Fixes #493
Fixes #494

One PR closing all four issues assigned to Mirabel64.

## #491 — scratch_test.rs cleanup + orphan-module lint

- Removed the leftover `apexchainx_calculator/scratch_test.rs` (never declared as a module, never compiled, its `test_sym` helper a trap for contributors).
- Added `scripts/check-orphan-modules.sh`: fails when any `.rs` file under the crate is never declared as a module — a file invisible to `cargo check`/`clippy`/`test` rots silently. Wired into CI as an early gate in `client-checks` and exposed as `just lint-orphans` (added to `just ci`).
- Contributor docs now state where throwaway code belongs: `CODING_STYLE.md` Part 4 (module-declaration + scratch-code policy) and a new bullet in `CONTRIBUTING.md` Step 2.
- The src/ orphans tracked by companion issue #422 (restored in PR #545) are allowlisted with a comment; the lint warns when the allowlist goes stale, so it self-cleans once #545 lands.

## #492 — get_public_api descriptor completeness guardrail

- Added `CANONICAL_PUBLIC_METHODS` (the impl-truth list, 61 methods with documented mutates/auth/event metadata) plus two tests in `tests.rs`:
  - `test_492_descriptor_covers_every_public_method` — fails when a public `#[contractimpl]` method is absent from `get_public_api`.
  - `test_492_descriptor_lists_only_declared_methods` — fails when the descriptor lists a method the impl no longer exposes.
- The section comment documents the three-way sync rule (impl block ⇄ `get_public_api` ⇄ canonical list) as the enforcement mechanism.

## #493 — pause_info Option workaround standardization

- Documented the single convention governing "absent" state across `#[contracttype]` surfaces in `CODING_STYLE.md` Part 3: `Vec<T>` with a max-length invariant (empty = absent, one element = present); getters keep `Result<Option<T>, _>`. Referenced from `CONTRIBUTING.md`.
- Enforced the `AuditState.pause_info` invariant with `test_audit_state_pause_info_invariant_across_pause_cycle` (empty when unpaused, exactly one when paused, always matching `get_pause_info`), and updated the field docs to carry the `INVARIANT: len() <= 1` note.

## #494 — fingerprint no longer masks a corrupt config as hash 0

- `get_contract_state_fingerprint` now propagates a config-hash failure (`?` instead of `unwrap_or(0)`): a legitimate `config_version_hash` is never 0 (polynomial seed is 1), so the old sentinel made a corrupt config indistinguishable from a valid state.
- Error contract updated in the doc comment (`NotInitialized`/`ConfigNotFound` when the config is unreadable; all *readable* states still return a valid fingerprint, including pre-migration).
- New tests: `test_494_fingerprint_fails_when_config_key_missing`, `test_494_fingerprint_fails_when_config_partially_missing`, and `test_494_fingerprint_hash_never_zero_on_readable_config`.

## Verification

- `cargo test --lib` — 598 passed, 0 failed (9 new/related tests pass)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo check --target wasm32-unknown-unknown --lib` — clean (no_std)
- `./scripts/check-no-std.sh` and `./scripts/check-orphan-modules.sh` — pass (lint verified to fail on a new orphan)
- TS parity fixtures unchanged (`ts/` has no diff)